### PR TITLE
Clippy and tokio fixes

### DIFF
--- a/gel-protocol/tests/datetime_chrono.rs
+++ b/gel-protocol/tests/datetime_chrono.rs
@@ -157,7 +157,7 @@ mod chrono {
         assert_eq!(format!("{:?}", edgedb), formatted);
 
         let mut buf = BytesMut::new();
-        let val = Value::Datetime(edgedb.clone());
+        let val = Value::Datetime(edgedb);
         codec::Datetime.encode(&mut buf, &val).unwrap();
         let serialized_micros = buf.get_i64();
 
@@ -314,7 +314,7 @@ mod chrono {
         assert_eq!(format!("{:?}", edgedb), formatted);
 
         let mut buf = BytesMut::new();
-        let val = Value::LocalDatetime(edgedb.clone());
+        let val = Value::LocalDatetime(edgedb);
         codec::LocalDatetime.encode(&mut buf, &val).unwrap();
         let serialized_micros = buf.get_i64();
 
@@ -388,7 +388,7 @@ mod chrono {
         assert_eq!(format!("{:?}", edgedb), formatted);
 
         let mut buf = BytesMut::new();
-        let val = Value::LocalTime(edgedb.clone());
+        let val = Value::LocalTime(edgedb);
         codec::LocalTime.encode(&mut buf, &val).unwrap();
         let serialized_micros = buf.get_i64();
 

--- a/gel-stream/src/common/openssl.rs
+++ b/gel-stream/src/common/openssl.rs
@@ -34,13 +34,8 @@ struct HandshakeData {
 
 impl HandshakeData {
     fn from_ssl(ssl: &SslRef) -> Option<MutexGuard<Self>> {
-        let Some(handshake) = ssl.ex_data(get_ssl_ex_data_index()) else {
-            return None;
-        };
-        let Ok(handshake) = handshake.lock() else {
-            return None;
-        };
-        Some(handshake)
+        let mutex = ssl.ex_data(get_ssl_ex_data_index())?;
+        mutex.lock().ok()
     }
 }
 

--- a/gel-stream/src/common/tokio_stream.rs
+++ b/gel-stream/src/common/tokio_stream.rs
@@ -62,6 +62,7 @@ impl ResolvedTarget {
             #[cfg(unix)]
             ResolvedTarget::UnixSocketAddr(path) => {
                 let stm = std::os::unix::net::UnixStream::connect_addr(path)?;
+                stm.set_nonblocking(true)?;
                 let stream = UnixStream::from_std(stm)?;
                 Ok(TokioStream::Unix(stream))
             }


### PR DESCRIPTION
Various clippy fixes and fix an issue with unix sockets in the latest Tokio (missing a `set_blocking(false)`)