### PR TITLE
Tweak the unix_path interface

### DIFF
--- a/gel-dsn/Cargo.toml
+++ b/gel-dsn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gel-dsn"
 license = "MIT/Apache-2.0"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2021"
 description = "Data-source name (DSN) parser for Gel and PostgreSQL databases."

--- a/gel-dsn/src/gel/mod.rs
+++ b/gel-dsn/src/gel/mod.rs
@@ -444,7 +444,7 @@ mod tests {
         // Test unix path with a port
         let cfg = Builder::new()
             .port(8888)
-            .unix_path(UnixPath::PortSuffixed(PathBuf::from("/prefix.")))
+            .unix_path(UnixPath::with_port_suffix(PathBuf::from("/prefix.")))
             .build()
             .unwrap();
         let host = cfg.host.target_name().unwrap();

--- a/gel-dsn/src/gel/mod.rs
+++ b/gel-dsn/src/gel/mod.rs
@@ -357,7 +357,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::host::{Host, HostTarget, HostType};
+    use crate::host::{Host, HostType};
     use std::{collections::HashMap, time::Duration};
 
     #[test]
@@ -370,11 +370,7 @@ mod tests {
         assert_eq!(
             cfg.unwrap(),
             Config {
-                host: Host::new(
-                    HostType::try_from_str("hostname").unwrap(),
-                    1234,
-                    HostTarget::Gel
-                ),
+                host: Host::new(HostType::try_from_str("hostname").unwrap(), 1234,),
                 ..Default::default()
             }
         );
@@ -398,10 +394,7 @@ mod tests {
             .build()
             .expect("Failed to build credentials");
 
-        assert_eq!(
-            credentials.host,
-            Host::new(DEFAULT_HOST.clone(), 10702, HostTarget::Gel)
-        );
+        assert_eq!(credentials.host, Host::new(DEFAULT_HOST.clone(), 10702));
         assert_eq!(&credentials.user, "test3n");
         assert_eq!(
             credentials.db,
@@ -441,12 +434,21 @@ mod tests {
 
         // Test unix path with a port
         let cfg = Builder::new()
-            .port(8888_u16)
+            .port(8888)
             .unix_path("/test")
             .build()
             .unwrap();
         let host = cfg.host.target_name().unwrap();
-        assert_eq!(host.path(), Some(Path::new("/test/.s.EDGEDB.admin.8888")));
+        assert_eq!(host.path(), Some(Path::new("/test")));
+
+        // Test unix path with a port
+        let cfg = Builder::new()
+            .port(8888)
+            .unix_path(UnixPath::PortSuffixed(PathBuf::from("/prefix.")))
+            .build()
+            .unwrap();
+        let host = cfg.host.target_name().unwrap();
+        assert_eq!(host.path(), Some(Path::new("/prefix.8888")));
     }
 
     /// Test that the hidden CloudCerts env var is parsed correctly.
@@ -455,7 +457,7 @@ mod tests {
         let cloud_cert =
             HashMap::from_iter([("_GEL_CLOUD_CERTS".to_string(), "local".to_string())]);
         let cfg = Builder::new()
-            .port(5656_u16)
+            .port(5656)
             .without_system()
             .with_env_impl(cloud_cert)
             .build()
@@ -466,7 +468,7 @@ mod tests {
     #[test]
     fn test_tcp_keepalive() {
         let cfg = Builder::new()
-            .port(5656_u16)
+            .port(5656)
             .tcp_keepalive(TcpKeepalive::Explicit(Duration::from_secs(10)))
             .without_system()
             .build()

--- a/gel-dsn/src/gel/param.rs
+++ b/gel-dsn/src/gel/param.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use super::{
     duration, error::*, BuildContext, ClientSecurity, CloudCerts, CloudCredentialsFile,
-    CredentialsFile, InstanceName, TcpKeepalive, TlsSecurity,
+    CredentialsFile, InstanceName, TcpKeepalive, TlsSecurity, UnixPath,
 };
 use crate::{gel::context_trace, host::HostType, EnvVar, FileAccess};
 
@@ -43,7 +43,8 @@ impl_from_param_str!(
     ClientSecurity,
     CloudCredentialsFile,
     CloudCerts,
-    TcpKeepalive
+    TcpKeepalive,
+    UnixPath
 );
 
 impl FromParamStr for std::time::Duration {

--- a/gel-dsn/src/user.rs
+++ b/gel-dsn/src/user.rs
@@ -28,6 +28,24 @@ impl UserProfile for () {
     }
 }
 
+impl UserProfile for &'static str {
+    fn username(&self) -> Option<Cow<str>> {
+        Some(Cow::Borrowed(self))
+    }
+
+    fn homedir(&self) -> Option<Cow<Path>> {
+        Some(Cow::Borrowed(Path::new("/home/edgedb")))
+    }
+
+    fn config_dir(&self) -> Option<Cow<Path>> {
+        Some(Cow::Borrowed(Path::new("/home/edgedb/.config")))
+    }
+
+    fn data_local_dir(&self) -> Option<Cow<Path>> {
+        Some(Cow::Borrowed(Path::new("/home/edgedb/.local")))
+    }
+}
+
 impl UserProfile for SystemUserProfile {
     fn username(&self) -> Option<Cow<str>> {
         whoami::fallible::username().ok().map(Cow::Owned)

--- a/gel-tokio/Cargo.toml
+++ b/gel-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gel-tokio"
 license = "MIT/Apache-2.0"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2021"
 description = """

--- a/gel-tokio/Cargo.toml
+++ b/gel-tokio/Cargo.toml
@@ -18,7 +18,7 @@ gel-protocol = { path = "../gel-protocol", version = "0.8", features = [
 gel-errors = { path = "../gel-errors", version = "0.5" }
 gel-derive = { path = "../gel-derive", version = "0.7", optional = true }
 gel-stream = { path = "../gel-stream", version = "0.2.1", features = ["client", "tokio", "rustls", "hickory", "keepalive"] }
-gel-dsn = { path = "../gel-dsn", version = "0.1.0", features = ["gel", "log", "auto-log-trace", "auto-log-warning"] }
+gel-dsn = { path = "../gel-dsn", version = "0.2.0", features = ["gel", "log", "auto-log-trace", "auto-log-warning"] }
 gel-auth = { path = "../gel-auth", version = "0.1.3" }
 tokio = { workspace = true, features = ["net", "time", "sync", "macros"] }
 bytes = "1.5.0"


### PR DESCRIPTION
We need a small tweak to the unix_path interface so that we can load the associated port from the instance credentials.

`UnixPath::with_port_suffix(...)`