### PR TITLE
Exclude the DSN tests from gel-dsn's published crate

### DIFF
--- a/gel-dsn/Cargo.toml
+++ b/gel-dsn/Cargo.toml
@@ -8,6 +8,8 @@ description = "Data-source name (DSN) parser for Gel and PostgreSQL databases."
 readme = "README.md"
 rust-version.workspace = true
 
+exclude = [ "tests" ]
+
 [features]
 default = []
 gel = ["serde"]


### PR DESCRIPTION
There is a decent amount of noise in these testscases that don't need to be published.