### PR TITLE
Rework the credentials code

### DIFF
--- a/gel-dsn/src/gel/config.rs
+++ b/gel-dsn/src/gel/config.rs
@@ -399,7 +399,7 @@ impl Config {
             .map_err(|_| CredentialsError::NoTcpAddress)?;
         let tcp = target.tcp().ok_or(CredentialsError::NoTcpAddress)?;
         Ok(CredentialsFile {
-            user: self.user.clone(),
+            user: Some(self.user.clone()),
             host: Some(tcp.0.to_string()),
             port: Some(NonZero::new(tcp.1).expect("invalid zero port")),
             password: self.authentication.password().map(|s| s.to_string()),

--- a/gel-dsn/src/gel/config.rs
+++ b/gel-dsn/src/gel/config.rs
@@ -26,6 +26,7 @@ pub const DEFAULT_POOL_SIZE: usize = 10;
 pub const DEFAULT_HOST: &HostType = crate::host::LOCALHOST;
 pub const DEFAULT_PORT: u16 = 5656;
 pub const DEFAULT_USER: &str = "edgedb";
+pub const DEFAULT_BRANCH: DatabaseBranch = DatabaseBranch::Default;
 
 /// The result of building a [`Config`].
 pub struct ConfigResult {

--- a/gel-dsn/src/gel/mod.rs
+++ b/gel-dsn/src/gel/mod.rs
@@ -314,7 +314,7 @@ impl<E: EnvVar, F: FileAccess> BuildContext for BuildContextImpl<E, F> {
     fn find_config_path(&self, path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
         for config_dir in self.config_dir.iter().flatten() {
             context_trace!(self, "Checking config path: {}", config_dir.display());
-            if matches!(self.files.exists_dir(&config_dir), Ok(true)) {
+            if matches!(self.files.exists_dir(config_dir), Ok(true)) {
                 return Ok(config_dir.join(path));
             }
         }

--- a/gel-dsn/src/gel/params.rs
+++ b/gel-dsn/src/gel/params.rs
@@ -1089,6 +1089,7 @@ fn parse_credentials(
         port: Param::from_parsed(credentials.port.map(|p| p.into())),
         user: Param::Unparsed(credentials.user.clone()),
         password: Param::from_unparsed(credentials.password.clone()),
+        secret_key: Param::from_unparsed(credentials.secret_key.clone()),
         database: Param::from_unparsed(credentials.database.clone()),
         branch: Param::from_unparsed(credentials.branch.clone()),
         tls_ca: Param::from_unparsed(credentials.tls_ca.clone()),
@@ -1200,6 +1201,7 @@ pub struct CredentialsFile {
     pub(crate) host: Option<String>,
     pub(crate) port: Option<NonZeroU16>,
     pub(crate) password: Option<String>,
+    pub(crate) secret_key: Option<String>,
     pub(crate) database: Option<String>,
     pub(crate) branch: Option<String>,
     pub(crate) tls_ca: Option<String>,
@@ -1256,6 +1258,8 @@ struct CredentialsFileCompat {
     user: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     password: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    secret_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     database: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1348,6 +1352,7 @@ impl TryInto<CredentialsFile> for CredentialsFileCompat {
                 port: self.port,
                 user: self.user,
                 password: self.password,
+                secret_key: self.secret_key,
                 database: self.database,
                 branch: self.branch,
                 tls_ca: self.tls_ca.or(self.tls_cert_data.clone()),

--- a/gel-dsn/src/host.rs
+++ b/gel-dsn/src/host.rs
@@ -79,7 +79,9 @@ impl std::fmt::Display for Host {
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct HostType(HostTypeInner);
 
-pub const LOCALHOST: &HostType = &HostType(HostTypeInner::Hostname(Cow::Borrowed("localhost")));
+pub const LOCALHOST_HOSTNAME: &str = "localhost";
+pub const LOCALHOST: &HostType =
+    &HostType(HostTypeInner::Hostname(Cow::Borrowed(LOCALHOST_HOSTNAME)));
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize))]

--- a/gel-tokio/src/lib.rs
+++ b/gel-tokio/src/lib.rs
@@ -131,61 +131,6 @@ unstable_pub_mods! {
 }
 
 pub use gel_dsn::gel::{Builder, CloudName, Config, InstanceName};
-pub mod credentials {
-    pub use gel_dsn::gel::TlsSecurity;
-
-    #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-    pub struct Credentials {
-        pub user: String,
-        pub host: Option<String>,
-        pub port: Option<u16>,
-        pub password: Option<String>,
-        pub database: Option<String>,
-        pub branch: Option<String>,
-        pub tls_ca: Option<String>,
-        #[serde(default)]
-        pub tls_security: TlsSecurity,
-        pub tls_server_name: Option<String>,
-    }
-    impl From<Credentials> for gel_dsn::gel::Params {
-        fn from(credentials: Credentials) -> Self {
-            use gel_dsn::gel::Param;
-            let mut params = gel_dsn::gel::Params::default();
-            params.user = Param::Unparsed(credentials.user);
-            params.host = Param::from_unparsed(credentials.host);
-            params.port = Param::from_parsed(credentials.port);
-            params.password = Param::from_unparsed(credentials.password);
-            params.database = Param::from_unparsed(credentials.database);
-            params.branch = Param::from_unparsed(credentials.branch);
-            params.tls_ca = Param::from_unparsed(credentials.tls_ca);
-            params.tls_security = Param::Parsed(credentials.tls_security);
-            params.tls_server_name = Param::from_unparsed(credentials.tls_server_name);
-            params
-        }
-    }
-
-    pub trait AsCredentials {
-        fn as_credentials(&self) -> anyhow::Result<Credentials>;
-    }
-
-    impl AsCredentials for gel_dsn::gel::Config {
-        fn as_credentials(&self) -> anyhow::Result<Credentials> {
-            let target = self.host.target_name()?;
-            let tcp = target.tcp().ok_or(anyhow::anyhow!("no TCP address"))?;
-            Ok(Credentials {
-                user: self.user.clone(),
-                host: Some(tcp.0.to_string()),
-                port: Some(tcp.1),
-                password: self.authentication.password().map(|s| s.to_string()),
-                database: self.db.name().map(|s| s.to_string()),
-                branch: self.db.branch().map(|s| s.to_string()),
-                tls_ca: self.tls_ca_pem(),
-                tls_security: self.tls_security,
-                tls_server_name: self.tls_server_name.clone(),
-            })
-        }
-    }
-}
 
 mod client;
 mod errors;

--- a/gel-tokio/src/lib.rs
+++ b/gel-tokio/src/lib.rs
@@ -130,7 +130,7 @@ unstable_pub_mods! {
     mod server_params;
 }
 
-pub use gel_dsn::gel::{Builder, CloudName, Config, InstanceName};
+pub use gel_dsn::gel::{Builder, CloudName, Config, InstanceName, TlsSecurity};
 
 mod client;
 mod errors;


### PR DESCRIPTION
Parse the new `secret_key` field. In addition, remove the custom `gel-tokio` implementation of the credentials.

All fields are now optional, simplifying the mental model.

The credentials -> DSN code was also hoisted into gel-dsn to simplify CLI code.