### PR TITLE
Use branding strings in gel-dsn

### DIFF
--- a/gel-dsn/src/gel/branding.rs
+++ b/gel-dsn/src/gel/branding.rs
@@ -1,0 +1,14 @@
+//! Branding strings.
+
+/// The product name.
+pub const BRANDING: &str = "Gel";
+/// The CLI name.
+pub const BRANDING_CLOUD: &str = "Gel Cloud";
+
+/// The display name for the project manifest file.
+pub const MANIFEST_FILE_DISPLAY_NAME: &str = "`gel.toml` or `edgedb.toml`";
+
+/// The default name of the database user bootstrapped in a new instance.
+#[allow(unused)]
+pub const BRANDING_DEFAULT_USERNAME: &str = "admin";
+pub const BRANDING_DEFAULT_USERNAME_LEGACY: &str = "edgedb";

--- a/gel-dsn/src/gel/config.rs
+++ b/gel-dsn/src/gel/config.rs
@@ -25,7 +25,7 @@ pub const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 pub const DEFAULT_POOL_SIZE: usize = 10;
 pub const DEFAULT_HOST: &HostType = crate::host::LOCALHOST;
 pub const DEFAULT_PORT: u16 = 5656;
-pub const DEFAULT_USER: &str = "edgedb";
+pub const DEFAULT_USER: &str = crate::gel::branding::BRANDING_DEFAULT_USERNAME_LEGACY;
 pub const DEFAULT_BRANCH: DatabaseBranch = DatabaseBranch::Default;
 
 /// The result of building a [`Config`].

--- a/gel-dsn/src/gel/error.rs
+++ b/gel-dsn/src/gel/error.rs
@@ -1,3 +1,4 @@
+use super::branding::*;
 use crate::host::HostParseError;
 use std::{convert::Infallible, num::ParseIntError};
 
@@ -86,7 +87,7 @@ pub enum ParseError {
     MultipleCompoundEnv(#[error(not(source))] Vec<CompoundSource>),
     #[display("Multiple compound options: {:?}", _0)]
     MultipleCompoundOpts(#[error(not(source))] Vec<CompoundSource>),
-    #[display("No options or .toml file")]
+    #[display("No connection options specified, and no project manifest file found ({MANIFEST_FILE_DISPLAY_NAME})")]
     NoOptionsOrToml,
     #[display("Project not initialized")]
     ProjectNotInitialised,

--- a/gel-dsn/src/gel/instance_name.rs
+++ b/gel-dsn/src/gel/instance_name.rs
@@ -136,7 +136,7 @@ impl fmt::Display for InstanceName {
             match self {
                 InstanceName::Local(name) => write!(f, "{BRANDING} instance '{}'", name),
                 InstanceName::Cloud(cloud_name) => {
-                    write!(f, "{BRANDING_CLOUD} Cloud instance '{}'", cloud_name)
+                    write!(f, "{BRANDING_CLOUD} instance '{}'", cloud_name)
                 }
             }
         } else {

--- a/gel-dsn/src/gel/mod.rs
+++ b/gel-dsn/src/gel/mod.rs
@@ -1,5 +1,6 @@
 //! Parses DSNs for Gel database connections.
 
+mod branding;
 mod config;
 mod duration;
 mod env;

--- a/gel-dsn/src/gel/params.rs
+++ b/gel-dsn/src/gel/params.rs
@@ -22,7 +22,7 @@ use super::{
 use crate::{
     env::SystemEnvVars,
     file::SystemFileAccess,
-    gel::{context_trace, Authentication},
+    gel::{context_trace, Authentication, DEFAULT_USER},
     host::{Host, HostType},
     user::SystemUserProfile,
     EnvVar, FileAccess, UserProfile,
@@ -934,7 +934,7 @@ impl Params {
             (_, TlsSecurity::Insecure) => TlsSecurity::Insecure,
         };
 
-        let user = user.unwrap_or_else(|| "edgedb".to_string());
+        let user = user.unwrap_or_else(|| DEFAULT_USER.to_string());
 
         let value = Some(Config {
             host,


### PR DESCRIPTION
We have a fair bit of code in `gel-cli` that repeats similar formatting for instance names. This moves the verbose InstanceName printing to gel-dsn so we can clean up some code downstream.