### PR TITLE
Add stored credentials API

### DIFF
--- a/gel-dsn/Cargo.toml
+++ b/gel-dsn/Cargo.toml
@@ -44,13 +44,14 @@ gel-auth = { path = "../gel-auth", version = "0" }
 gel-errors = { path = "../gel-errors", version = "0" }
 
 [dev-dependencies]
+gel-dsn = { path = ".", features = ["gel", "postgres", "unstable"] }
+
 rstest = "0.24"
 pretty_assertions = "1"
 libc = "0.2"
 paste = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-gel-dsn = { path = ".", features = ["gel", "postgres"] }
 tempfile = "3"
 
 [package.metadata.docs.rs]

--- a/gel-dsn/src/file.rs
+++ b/gel-dsn/src/file.rs
@@ -192,12 +192,10 @@ impl FileAccess for SystemFileAccess {
 
     fn list_dir(&self, path: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
         let mut files = vec![];
-        for file in std::fs::read_dir(path)? {
-            if let Ok(file) = file {
-                let path = file.path();
-                if path.is_file() {
-                    files.push(path);
-                }
+        for file in std::fs::read_dir(path)?.flatten() {
+            let path = file.path();
+            if path.is_file() {
+                files.push(path);
             }
         }
         Ok(files)
@@ -248,14 +246,14 @@ mod tests {
         let found = files
             .exists_dir(&PathBuf::from("/home/edgedb/.config/edgedb/credentials/"))
             .unwrap();
-        assert_eq!(found, true);
+        assert!(found);
         let found = files
             .exists_dir(&PathBuf::from("/home/edgedb/.config/edgedb/"))
             .unwrap();
-        assert_eq!(found, true);
+        assert!(found);
         let found = files
             .exists_dir(&PathBuf::from("/home/edgedb/.config/"))
             .unwrap();
-        assert_eq!(found, true);
+        assert!(found);
     }
 }

--- a/gel-dsn/src/file.rs
+++ b/gel-dsn/src/file.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    sync::Mutex,
 };
 
 pub struct SystemFileAccess;
@@ -30,10 +31,53 @@ pub trait FileAccess {
         }
     }
 
-    fn exists_dir(&self, path: &Path) -> Result<bool, std::io::Error>;
-
     fn canonicalize(&self, path: &Path) -> Result<PathBuf, std::io::Error> {
         Ok(path.to_path_buf())
+    }
+
+    /// Returns all files known by this file accessor. This is inefficient, but
+    /// only used for mock implementations.
+    fn all_files(&self) -> Option<Vec<PathBuf>> {
+        None
+    }
+
+    fn exists_dir(&self, path: &Path) -> Result<bool, std::io::Error> {
+        let Some(all_files) = self.all_files() else {
+            unreachable!("FileAccess::exists_dir incorrectly implemented");
+        };
+
+        Ok(all_files.iter().any(|file| {
+            if let Ok(file) = file.strip_prefix(path) {
+                file.components().count() >= 1
+            } else {
+                false
+            }
+        }))
+    }
+
+    fn list_dir(&self, path: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
+        let Some(all_files) = self.all_files() else {
+            unreachable!("FileAccess::list_dir incorrectly implemented");
+        };
+
+        Ok(all_files
+            .iter()
+            .filter(|file| {
+                if let Ok(file) = file.strip_prefix(path) {
+                    file.components().count() == 1
+                } else {
+                    false
+                }
+            })
+            .cloned()
+            .collect())
+    }
+
+    fn write(&self, _: &Path, _: &str) -> Result<(), std::io::Error> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "FileAccess::write_file is not implemented",
+        ))
     }
 }
 
@@ -48,8 +92,8 @@ impl FileAccess for &[(&Path, &str)] {
             ))
     }
 
-    fn exists_dir(&self, path: &Path) -> Result<bool, std::io::Error> {
-        Ok(self.iter().any(|(key, _)| key.starts_with(path)))
+    fn all_files(&self) -> Option<Vec<PathBuf>> {
+        Some(self.iter().map(|(key, _)| key.into()).collect())
     }
 }
 
@@ -67,8 +111,40 @@ where
             ))
     }
 
-    fn exists_dir(&self, path: &Path) -> Result<bool, std::io::Error> {
-        Ok(self.iter().any(|(key, _)| key.borrow().starts_with(path)))
+    fn all_files(&self) -> Option<Vec<PathBuf>> {
+        Some(self.keys().map(|key| key.borrow().into()).collect())
+    }
+}
+
+impl<K, V> FileAccess for Mutex<HashMap<K, V>>
+where
+    K: std::hash::Hash + Eq + std::borrow::Borrow<Path> + for<'a> From<&'a Path>,
+    V: std::borrow::Borrow<str> + for<'a> From<&'a str>,
+{
+    fn read(&self, name: &Path) -> Result<String, std::io::Error> {
+        self.lock()
+            .unwrap()
+            .get(name)
+            .map(|value| value.borrow().into())
+            .ok_or(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "File not found",
+            ))
+    }
+
+    fn write(&self, path: &Path, content: &str) -> Result<(), std::io::Error> {
+        self.lock().unwrap().insert(path.into(), content.into());
+        Ok(())
+    }
+
+    fn all_files(&self) -> Option<Vec<PathBuf>> {
+        Some(
+            self.lock()
+                .unwrap()
+                .keys()
+                .map(|key| key.borrow().into())
+                .collect(),
+        )
     }
 }
 
@@ -82,6 +158,10 @@ impl FileAccess for () {
 
     fn exists_dir(&self, _: &Path) -> Result<bool, std::io::Error> {
         Ok(false)
+    }
+
+    fn all_files(&self) -> Option<Vec<PathBuf>> {
+        Some(Vec::new())
     }
 }
 
@@ -108,5 +188,74 @@ impl FileAccess for SystemFileAccess {
 
     fn canonicalize(&self, path: &Path) -> Result<PathBuf, std::io::Error> {
         std::fs::canonicalize(path)
+    }
+
+    fn list_dir(&self, path: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
+        let mut files = vec![];
+        for file in std::fs::read_dir(path)? {
+            if let Ok(file) = file {
+                let path = file.path();
+                if path.is_file() {
+                    files.push(path);
+                }
+            }
+        }
+        Ok(files)
+    }
+
+    fn all_files(&self) -> Option<Vec<PathBuf>> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_dir() {
+        let mut files = HashMap::new();
+        files.insert(
+            PathBuf::from("/home/edgedb/.config/edgedb/credentials/local.json"),
+            "{}",
+        );
+        files.insert(
+            PathBuf::from("/home/edgedb/.config/edgedb/credentials/local2.json"),
+            "{}",
+        );
+        let found = files
+            .list_dir(&PathBuf::from("/home/edgedb/.config/edgedb/credentials/"))
+            .unwrap();
+        assert_eq!(found.len(), 2);
+        let found = files
+            .list_dir(&PathBuf::from("/home/edgedb/.config/edgedb/"))
+            .unwrap();
+        assert_eq!(found.len(), 0);
+    }
+
+    #[test]
+    fn test_exists_dir() {
+        let files = Mutex::new(HashMap::<PathBuf, String>::new());
+        assert!(!files
+            .exists_dir(&PathBuf::from("/home/edgedb/.config/edgedb/credentials/"))
+            .unwrap());
+        files
+            .write(
+                &PathBuf::from("/home/edgedb/.config/edgedb/credentials/local.json"),
+                "{}",
+            )
+            .unwrap();
+        let found = files
+            .exists_dir(&PathBuf::from("/home/edgedb/.config/edgedb/credentials/"))
+            .unwrap();
+        assert_eq!(found, true);
+        let found = files
+            .exists_dir(&PathBuf::from("/home/edgedb/.config/edgedb/"))
+            .unwrap();
+        assert_eq!(found, true);
+        let found = files
+            .exists_dir(&PathBuf::from("/home/edgedb/.config/"))
+            .unwrap();
+        assert_eq!(found, true);
     }
 }

--- a/gel-dsn/src/file.rs
+++ b/gel-dsn/src/file.rs
@@ -201,6 +201,10 @@ impl FileAccess for SystemFileAccess {
         Ok(files)
     }
 
+    fn write(&self, path: &Path, content: &str) -> Result<(), std::io::Error> {
+        std::fs::write(path, content)
+    }
+
     fn all_files(&self) -> Option<Vec<PathBuf>> {
         None
     }

--- a/gel-dsn/src/gel/config.rs
+++ b/gel-dsn/src/gel/config.rs
@@ -28,6 +28,9 @@ pub const DEFAULT_PORT: u16 = 5656;
 pub const DEFAULT_USER: &str = crate::gel::branding::BRANDING_DEFAULT_USERNAME_LEGACY;
 pub const DEFAULT_BRANCH: DatabaseBranch = DatabaseBranch::Default;
 
+pub const DEFAULT_DATABASE_NAME: &str = "edgedb";
+pub const DEFAULT_BRANCH_NAME: &str = "__default__";
+
 /// The result of building a [`Config`].
 pub struct ConfigResult {
     pub(crate) result: Result<Config, gel_errors::Error>,
@@ -519,7 +522,7 @@ impl DatabaseBranch {
             // Special case: we return branch here
             Self::Branch(branch) => Some(branch),
             Self::Ambiguous(ambiguous) => Some(ambiguous),
-            Self::Default => Some("edgedb"),
+            Self::Default => Some(DEFAULT_DATABASE_NAME),
         }
     }
 
@@ -529,7 +532,7 @@ impl DatabaseBranch {
             // Special case: we return database here
             Self::Database(database) => Some(database),
             Self::Ambiguous(ambiguous) => Some(ambiguous),
-            Self::Default => Some("__default__"),
+            Self::Default => Some(DEFAULT_BRANCH_NAME),
         }
     }
 
@@ -728,6 +731,7 @@ enum UnixPathInner {
     Exact(PathBuf),
 }
 
+/// A path to a Unix socket.
 #[derive(Clone, PartialEq, Eq, derive_more::Debug)]
 pub struct UnixPath {
     #[debug("{:?}", inner)]

--- a/gel-dsn/src/gel/config.rs
+++ b/gel-dsn/src/gel/config.rs
@@ -340,7 +340,7 @@ impl Config {
     pub fn with_pem_certificates(&self, certs: &str) -> Result<Self, ParseError> {
         let certs = <Vec<CertificateDer<'static>> as FromParamStr>::from_param_str(
             certs,
-            &mut BuildContextImpl::default(),
+            &BuildContextImpl::default(),
         )?;
         Ok(Self {
             tls_ca: Some(certs),

--- a/gel-dsn/src/gel/credentials.rs
+++ b/gel-dsn/src/gel/credentials.rs
@@ -214,13 +214,15 @@ impl TryInto<CredentialsFile> for CredentialsFileCompat {
             }
 
             // Special case: don't allow database and branch to be set at the same time
-            if database.is_some() && branch.is_some() && database != branch {
-                return Err(ParseError::InvalidCredentialsFile(
-                    InvalidCredentialsFileError::ConflictingSettings(
-                        ("database".to_string(), database.unwrap().to_string()),
-                        ("branch".to_string(), branch.unwrap().to_string()),
-                    ),
-                ));
+            if let (Some(database), Some(branch)) = (&database, &branch) {
+                if database != branch {
+                    return Err(ParseError::InvalidCredentialsFile(
+                        InvalidCredentialsFileError::ConflictingSettings(
+                            ("database".to_string(), database.to_string()),
+                            ("branch".to_string(), branch.to_string()),
+                        ),
+                    ));
+                }
             }
 
             Ok(CredentialsFile {

--- a/gel-dsn/src/gel/credentials.rs
+++ b/gel-dsn/src/gel/credentials.rs
@@ -1,0 +1,286 @@
+use std::{num::NonZeroU16, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    error::*, Param, Params, TlsSecurity, DEFAULT_BRANCH_NAME, DEFAULT_DATABASE_NAME, DEFAULT_HOST,
+    DEFAULT_PORT,
+};
+
+/// An opaque type representing a credentials file.
+///
+/// Use [`std::str::FromStr`] to parse a credentials file from a string.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CredentialsFile {
+    pub user: Option<String>,
+    pub host: Option<String>,
+    pub port: Option<NonZeroU16>,
+    pub password: Option<String>,
+    pub secret_key: Option<String>,
+    pub database: Option<String>,
+    pub branch: Option<String>,
+    pub tls_ca: Option<String>,
+    #[serde(default)]
+    pub tls_security: TlsSecurity,
+    pub tls_server_name: Option<String>,
+
+    #[serde(skip)]
+    pub(crate) warnings: Vec<Warning>,
+}
+
+impl From<&CredentialsFile> for Params {
+    fn from(credentials: &CredentialsFile) -> Self {
+        let host = if let Some(host) = credentials.host.clone() {
+            Param::Unparsed(host)
+        } else {
+            Param::Parsed(DEFAULT_HOST.clone())
+        };
+        let port = if let Some(port) = credentials.port {
+            Param::Parsed(port.into())
+        } else {
+            Param::Parsed(DEFAULT_PORT)
+        };
+
+        Params {
+            host,
+            port,
+            user: Param::from_unparsed(credentials.user.clone()),
+            password: Param::from_unparsed(credentials.password.clone()),
+            secret_key: Param::from_unparsed(credentials.secret_key.clone()),
+            database: Param::from_unparsed(credentials.database.clone()),
+            branch: Param::from_unparsed(credentials.branch.clone()),
+            tls_ca: Param::from_unparsed(credentials.tls_ca.clone()),
+            tls_security: Param::Parsed(credentials.tls_security),
+            tls_server_name: Param::from_unparsed(credentials.tls_server_name.clone()),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<CredentialsFile> for Params {
+    fn from(credentials: CredentialsFile) -> Self {
+        Self::from(&credentials)
+    }
+}
+
+impl CredentialsFile {
+    pub fn warnings(&self) -> &[Warning] {
+        &self.warnings
+    }
+}
+
+impl FromStr for CredentialsFile {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(mut res) = serde_json::from_str::<CredentialsFile>(s) {
+            // Special case: treat database=__default__ and branch=edgedb as not set
+            if (Some(DEFAULT_DATABASE_NAME), Some(DEFAULT_BRANCH_NAME))
+                == (res.database.as_deref(), res.branch.as_deref())
+            {
+                res.database = None;
+                res.branch = None;
+            }
+
+            // Special case: don't allow database and branch to be set at the same time
+            if let (Some(database), Some(branch)) = (&res.database, &res.branch) {
+                if database != branch {
+                    return Err(ParseError::InvalidCredentialsFile(
+                        InvalidCredentialsFileError::ConflictingSettings(
+                            ("database".to_string(), database.clone()),
+                            ("branch".to_string(), branch.clone()),
+                        ),
+                    ));
+                }
+            }
+
+            return Ok(res);
+        }
+
+        let res = serde_json::from_str::<CredentialsFileCompat>(s).map_err(|e| {
+            ParseError::InvalidCredentialsFile(InvalidCredentialsFileError::SerializationError(
+                e.to_string(),
+            ))
+        })?;
+
+        res.try_into()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CredentialsFileCompat {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    port: Option<NonZeroU16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    password: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    secret_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    database: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tls_cert_data: Option<String>, // deprecated
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tls_ca: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tls_server_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tls_verify_hostname: Option<bool>, // deprecated
+    tls_security: Option<TlsSecurity>,
+}
+
+impl CredentialsFileCompat {
+    fn validate(&self) -> Vec<Warning> {
+        let mut warnings = Vec::new();
+        if self.database.as_deref() == Some(DEFAULT_DATABASE_NAME)
+            && self.branch.as_deref() == Some(DEFAULT_BRANCH_NAME)
+        {
+            warnings.push(Warning::DefaultDatabaseAndBranch);
+        }
+        if self.tls_verify_hostname.is_some() {
+            warnings.push(Warning::DeprecatedCredentialProperty(
+                "tls_verify_hostname".to_string(),
+            ));
+        }
+        if self.tls_cert_data.is_some() {
+            warnings.push(Warning::DeprecatedCredentialProperty(
+                "tls_cert_data".to_string(),
+            ));
+        }
+        warnings
+    }
+}
+
+impl TryInto<CredentialsFile> for CredentialsFileCompat {
+    type Error = ParseError;
+
+    fn try_into(self) -> Result<CredentialsFile, Self::Error> {
+        let expected_verify = match self.tls_security {
+            Some(TlsSecurity::Strict) => Some(true),
+            Some(TlsSecurity::NoHostVerification) => Some(false),
+            Some(TlsSecurity::Insecure) => Some(false),
+            _ => None,
+        };
+        if self.tls_verify_hostname.is_some()
+            && self.tls_security.is_some()
+            && expected_verify
+                .zip(self.tls_verify_hostname)
+                .map(|(actual, expected)| actual != expected)
+                .unwrap_or(false)
+        {
+            Err(ParseError::InvalidCredentialsFile(
+                InvalidCredentialsFileError::ConflictingSettings(
+                    (
+                        "tls_security".to_string(),
+                        self.tls_security.unwrap().to_string(),
+                    ),
+                    (
+                        "tls_verify_hostname".to_string(),
+                        self.tls_verify_hostname.unwrap().to_string(),
+                    ),
+                ),
+            ))
+        } else if self.tls_ca.is_some()
+            && self.tls_cert_data.is_some()
+            && self.tls_ca != self.tls_cert_data
+        {
+            return Err(ParseError::InvalidCredentialsFile(
+                InvalidCredentialsFileError::ConflictingSettings(
+                    ("tls_ca".to_string(), self.tls_ca.unwrap().to_string()),
+                    (
+                        "tls_cert_data".to_string(),
+                        self.tls_cert_data.unwrap().to_string(),
+                    ),
+                ),
+            ));
+        } else {
+            let warnings = self.validate();
+
+            let mut database = self.database;
+            let mut branch = self.branch;
+
+            // Special case: treat database=__default__ and branch=edgedb as not set
+            if (Some(DEFAULT_DATABASE_NAME), Some(DEFAULT_BRANCH_NAME))
+                == (database.as_deref(), branch.as_deref())
+            {
+                database = None;
+                branch = None;
+            }
+
+            // Special case: don't allow database and branch to be set at the same time
+            if database.is_some() && branch.is_some() && database != branch {
+                return Err(ParseError::InvalidCredentialsFile(
+                    InvalidCredentialsFileError::ConflictingSettings(
+                        ("database".to_string(), database.unwrap().to_string()),
+                        ("branch".to_string(), branch.unwrap().to_string()),
+                    ),
+                ));
+            }
+
+            Ok(CredentialsFile {
+                host: self.host,
+                port: self.port,
+                user: self.user,
+                password: self.password,
+                secret_key: self.secret_key,
+                database,
+                branch,
+                tls_ca: self.tls_ca.or(self.tls_cert_data.clone()),
+                tls_server_name: self.tls_server_name,
+                tls_security: self.tls_security.unwrap_or(match self.tls_verify_hostname {
+                    None => TlsSecurity::Default,
+                    Some(true) => TlsSecurity::Strict,
+                    Some(false) => TlsSecurity::NoHostVerification,
+                }),
+                warnings,
+            })
+        }
+    }
+}
+
+/// An opaque type representing a cloud credentials file.
+///
+/// Use [`std::str::FromStr`] to parse a cloud credentials file from a string.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CloudCredentialsFile {
+    pub(crate) secret_key: String,
+}
+
+impl FromStr for CloudCredentialsFile {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s).map_err(|e| {
+            ParseError::InvalidCredentialsFile(InvalidCredentialsFileError::SerializationError(
+                e.to_string(),
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_credentials_file() {
+        let credentials = CredentialsFile::from_str("{\"branch\": \"edgedb\"}").unwrap();
+        assert_eq!(credentials.branch, Some("edgedb".to_string()));
+        assert_eq!(credentials.database, None);
+    }
+
+    #[test]
+    fn test_credentials_file_default_database_and_branch() {
+        let credentials =
+            CredentialsFile::from_str("{\"database\": \"edgedb\", \"branch\": \"__default__\"}")
+                .unwrap();
+        assert_eq!(credentials.database, None);
+        assert_eq!(credentials.branch, None);
+    }
+}

--- a/gel-dsn/src/gel/env.rs
+++ b/gel-dsn/src/gel/env.rs
@@ -3,7 +3,6 @@ use super::{
     TlsSecurity,
 };
 use crate::host::HostType;
-use crate::EnvVar;
 use std::{borrow::Cow, fmt::Debug, num::NonZeroU16, path::PathBuf, time::Duration};
 
 define_env!(
@@ -85,7 +84,7 @@ define_env!(
 
 fn ignore_docker_tcp_port(
     s: &str,
-    context: &mut impl BuildContext,
+    context: &impl BuildContext,
 ) -> Result<Option<String>, ParseError> {
     if s.starts_with("tcp://") {
         context.warn(Warning::DockerPortIgnored(
@@ -122,7 +121,7 @@ macro_rules! __UNEXPORTED_define_env {
         impl Env {
             $(
                 #[doc = $doc]
-                pub fn $name(context: &mut impl $crate::gel::BuildContext) -> ::std::result::Result<::std::option::Option<$type>, $error> {
+                pub fn $name(context: &impl $crate::gel::BuildContext) -> ::std::result::Result<::std::option::Option<$type>, $error> {
                     const ENV_NAMES: &[&str] = &[$(stringify!($env_name)),+];
                     let Some((_name, s)) = $crate::gel::env::get_envs(ENV_NAMES, context)? else {
                         return Ok(None);
@@ -154,10 +153,7 @@ macro_rules! __UNEXPORTED_define_env {
 
 #[inline(never)]
 #[doc(hidden)]
-pub fn parse<T: FromParamStr, E>(
-    s: impl AsRef<str>,
-    context: &mut impl BuildContext,
-) -> Result<T, E>
+pub fn parse<T: FromParamStr, E>(s: impl AsRef<str>, context: &impl BuildContext) -> Result<T, E>
 where
     <T as FromParamStr>::Err: Into<E>,
 {
@@ -171,13 +167,13 @@ where
 #[doc(hidden)]
 pub fn get_envs(
     names: &'static [&'static str],
-    context: &mut impl BuildContext,
+    context: &impl BuildContext,
 ) -> Result<Option<(&'static str, Cow<'static, str>)>, ParseError> {
     let mut value = None;
     let mut found_vars = Vec::new();
 
     for name in names {
-        match context.env().read(name) {
+        match context.read_env(name) {
             Ok(val) => {
                 found_vars.push(format!("{}={}", name, val));
                 if value.is_none() {

--- a/gel-dsn/src/gel/env.rs
+++ b/gel-dsn/src/gel/env.rs
@@ -219,10 +219,7 @@ mod tests {
         let mut context = BuildContextImpl::new_with(&map, ());
         let warnings = Warnings::default();
         context.logging.warning = Some(warnings.clone().warn_fn());
-        assert_eq!(
-            Env::host(&mut context).unwrap(),
-            Some("localhost".to_string())
-        );
+        assert_eq!(Env::host(&context).unwrap(), Some("localhost".to_string()));
         assert_eq!(
             warnings.into_vec(),
             vec![Warning::MultipleEnvironmentVariables(vec![

--- a/gel-dsn/src/gel/error.rs
+++ b/gel-dsn/src/gel/error.rs
@@ -200,6 +200,8 @@ pub enum Warning {
     MultipleEnvironmentVariables(Vec<String>),
     #[display("{_0} is ignored when using Docker TCP port")]
     DockerPortIgnored(String),
+    #[display("Database and branch are set to default values")]
+    DefaultDatabaseAndBranch,
 }
 
 #[derive(Debug, Default)]

--- a/gel-dsn/src/gel/mod.rs
+++ b/gel-dsn/src/gel/mod.rs
@@ -316,6 +316,9 @@ impl<E: EnvVar, F: FileAccess> BuildContext for BuildContextImpl<E, F> {
         content: &str,
     ) -> Result<(), std::io::Error> {
         let path = path.as_ref();
+        // TODO: We need to be able to handle multiple config dirs. For now, just
+        // use the first one.
+        #[allow(clippy::never_loop)]
         for config_dir in self.config_dir.iter().flatten() {
             let path = config_dir.join(path);
             context_trace!(self, "Writing config file: {}", path.display());

--- a/gel-dsn/src/gel/mod.rs
+++ b/gel-dsn/src/gel/mod.rs
@@ -2,6 +2,7 @@
 
 mod branding;
 mod config;
+mod credentials;
 mod duration;
 mod env;
 pub mod error;
@@ -9,6 +10,7 @@ mod instance_name;
 mod param;
 mod params;
 mod project;
+mod stored;
 
 use std::{
     path::{Path, PathBuf},
@@ -20,6 +22,7 @@ use crate::{
     UserProfile,
 };
 pub use config::*;
+pub use credentials::*;
 use error::Warning;
 pub use instance_name::*;
 pub use param::*;
@@ -30,6 +33,9 @@ pub use env::define_env;
 
 #[cfg(feature = "unstable")]
 pub use project::{Project, ProjectDir, ProjectSearchResult};
+
+#[cfg(feature = "unstable")]
+pub use stored::{StoredCredentials, StoredInformation};
 
 /// Internal helper to parse a duration string into a `std::time::Duration`.
 #[doc(hidden)]
@@ -67,7 +73,7 @@ type LoggingFn = Box<dyn Fn(&str) + 'static>;
 type WarningFn = Box<dyn Fn(Warning) + 'static>;
 
 #[derive(Default)]
-struct Logging {
+pub(crate) struct Logging {
     tracing: Option<LoggingFn>,
     warning: Option<WarningFn>,
     #[cfg(feature = "log")]
@@ -190,7 +196,7 @@ impl Traces {
     }
 }
 
-struct BuildContextImpl<E: EnvVar = SystemEnvVars, F: FileAccess = SystemFileAccess> {
+pub(crate) struct BuildContextImpl<E: EnvVar = SystemEnvVars, F: FileAccess = SystemFileAccess> {
     env: E,
     files: F,
     pub config_dir: Option<Vec<PathBuf>>,
@@ -248,33 +254,25 @@ macro_rules! context_trace {
 pub(crate) use context_trace;
 
 pub(crate) trait BuildContext {
-    type EnvVar: EnvVar;
-    fn env(&self) -> &impl EnvVar;
     fn cwd(&self) -> Option<PathBuf>;
     fn files(&self) -> &impl FileAccess;
-    fn warn(&mut self, warning: error::Warning);
+    fn warn(&self, warning: error::Warning);
     fn read_config_file<T: FromParamStr>(
-        &mut self,
+        &self,
         path: impl AsRef<Path>,
     ) -> Result<Option<T>, T::Err>;
+    fn write_config_file(
+        &self,
+        path: impl AsRef<Path>,
+        content: &str,
+    ) -> Result<(), std::io::Error>;
     fn find_config_path(&self, path: impl AsRef<Path>) -> std::io::Result<PathBuf>;
-    fn read_env<'a, 'b, 'c, T: FromParamStr>(
-        &'c mut self,
-        env: impl Fn(&'b mut Self) -> Result<Option<T>, error::ParseError>,
-    ) -> Result<Option<T>, error::ParseError>
-    where
-        Self::EnvVar: 'a,
-        'c: 'a,
-        'c: 'b;
+    fn list_config_files(&self, path: impl AsRef<Path>) -> Result<Vec<PathBuf>, std::io::Error>;
+    fn read_env(&self, name: &str) -> Result<std::borrow::Cow<str>, std::env::VarError>;
     fn trace(&self, message: impl Fn(&dyn Fn(&str)));
 }
 
 impl<E: EnvVar, F: FileAccess> BuildContext for BuildContextImpl<E, F> {
-    type EnvVar = E;
-    fn env(&self) -> &impl EnvVar {
-        &self.env
-    }
-
     fn cwd(&self) -> Option<PathBuf> {
         self.files.cwd()
     }
@@ -283,12 +281,12 @@ impl<E: EnvVar, F: FileAccess> BuildContext for BuildContextImpl<E, F> {
         &self.files
     }
 
-    fn warn(&mut self, warning: error::Warning) {
+    fn warn(&self, warning: error::Warning) {
         self.logging.warn(warning);
     }
 
     fn read_config_file<T: FromParamStr>(
-        &mut self,
+        &self,
         path: impl AsRef<Path>,
     ) -> Result<Option<T>, T::Err> {
         for config_dir in self.config_dir.iter().flatten() {
@@ -312,6 +310,38 @@ impl<E: EnvVar, F: FileAccess> BuildContext for BuildContextImpl<E, F> {
         Ok(None)
     }
 
+    fn write_config_file(
+        &self,
+        path: impl AsRef<Path>,
+        content: &str,
+    ) -> Result<(), std::io::Error> {
+        let path = path.as_ref();
+        for config_dir in self.config_dir.iter().flatten() {
+            let path = config_dir.join(path);
+            context_trace!(self, "Writing config file: {}", path.display());
+            self.files.write(&path, content)?;
+            return Ok(());
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Config path not found",
+        ))
+    }
+
+    fn list_config_files(&self, path: impl AsRef<Path>) -> Result<Vec<PathBuf>, std::io::Error> {
+        let mut files = Vec::new();
+        for config_dir in self.config_dir.iter().flatten() {
+            let path = config_dir.join(path.as_ref());
+            context_trace!(self, "Checking config path: {}", path.display());
+            for file in self.files.list_dir(&path)? {
+                context_trace!(self, "Found config file: {}", file.display());
+                files.push(file);
+            }
+        }
+
+        Ok(files)
+    }
+
     fn find_config_path(&self, path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
         for config_dir in self.config_dir.iter().flatten() {
             context_trace!(self, "Checking config path: {}", config_dir.display());
@@ -331,21 +361,8 @@ impl<E: EnvVar, F: FileAccess> BuildContext for BuildContextImpl<E, F> {
         ))
     }
 
-    fn read_env<'a, 'b, 'c, T: FromParamStr>(
-        &'c mut self,
-        env: impl Fn(&'b mut Self) -> Result<Option<T>, error::ParseError>,
-    ) -> Result<Option<T>, error::ParseError>
-    where
-        Self::EnvVar: 'a,
-        'c: 'a,
-        'c: 'b,
-    {
-        let res = env(self);
-        match res {
-            Ok(Some(value)) => Ok(Some(value)),
-            Ok(None) => Ok(None),
-            Err(e) => Err(e),
-        }
+    fn read_env(&self, name: &str) -> Result<std::borrow::Cow<str>, std::env::VarError> {
+        self.env.read(name)
     }
 
     fn trace(&self, message: impl Fn(&dyn Fn(&str))) {

--- a/gel-dsn/src/gel/param.rs
+++ b/gel-dsn/src/gel/param.rs
@@ -284,10 +284,9 @@ mod tests {
             "edgedb://username%25@password%25:[::1%25lo0]:5656/db/",
             "edgedb://user3@[fe80::1ff:fe23:4567:890a%25lo0]:3000/ab",
         ] {
-            let result = <Url as FromParamStr>::from_param_str(dsn, &mut BuildContextImpl::new());
+            let result = <Url as FromParamStr>::from_param_str(dsn, &BuildContextImpl::new());
             let dsn2 = dsn.replace("%25lo0", "");
-            let result2 =
-                <Url as FromParamStr>::from_param_str(&dsn2, &mut BuildContextImpl::new());
+            let result2 = <Url as FromParamStr>::from_param_str(&dsn2, &BuildContextImpl::new());
             eprintln!("{dsn} = {result:?}, {dsn2} = {result2:?}");
             assert_eq!(
                 result, result2,

--- a/gel-dsn/src/gel/params.rs
+++ b/gel-dsn/src/gel/params.rs
@@ -16,8 +16,7 @@ use super::{
     stored::{StoredCredentials, StoredInformation},
     BuildContext, BuildContextImpl, ClientSecurity, CloudCerts, CloudCredentialsFile, Config,
     CredentialsFile, DatabaseBranch, FromParamStr, InstanceName, Logging, Param, ParamSource,
-    TcpKeepalive, TlsSecurity, UnixPath, DEFAULT_CONNECT_TIMEOUT, DEFAULT_HOST, DEFAULT_PORT,
-    DEFAULT_WAIT,
+    TcpKeepalive, TlsSecurity, UnixPath, DEFAULT_CONNECT_TIMEOUT, DEFAULT_PORT, DEFAULT_WAIT,
 };
 use crate::{
     env::SystemEnvVars,
@@ -699,7 +698,7 @@ impl<E: BuilderEnv, F: BuilderFs, U: BuilderUser, P: BuilderProject> BuilderPrep
 
         let mut context = BuildContextImpl::new_with_user_profile(self.env, self.fs, self.user);
         context.logging = self.logging;
-        compute(params, &mut context, self.project_dir)
+        compute(params, &context, self.project_dir)
     }
 
     /// Read and write stored credentials and project information.
@@ -717,7 +716,7 @@ impl<E: BuilderEnv, F: BuilderFs, U: BuilderUser, P: BuilderProject> BuilderPrep
 
         let mut context = BuildContextImpl::new_with_user_profile(self.env, self.fs, self.user);
         context.logging = self.logging;
-        parse(params, &mut context, self.project_dir)
+        parse(params, &context, self.project_dir)
     }
 }
 

--- a/gel-dsn/src/gel/project.rs
+++ b/gel-dsn/src/gel/project.rs
@@ -56,7 +56,7 @@ impl ProjectDir {
 
 /// Searches for a project file either from the current directory or from a
 pub fn find_project_file(
-    context: &mut impl BuildContext,
+    context: &impl BuildContext,
     start_path: ProjectDir,
 ) -> io::Result<Option<ProjectSearchResult>> {
     let project_path = if let ProjectDir::Exact(path) = start_path {
@@ -126,7 +126,7 @@ fn stash_name(path: &Path) -> OsString {
 
 /// Searches for project files in the given directory and optionally its parents.
 fn search_directory(
-    context: &mut impl BuildContext,
+    context: &impl BuildContext,
     base: &Path,
     search_parents: bool,
 ) -> io::Result<Option<PathBuf>> {
@@ -175,7 +175,7 @@ fn search_directory(
 }
 
 /// Computes the path to the project's stash file based on the canonical path.
-fn get_stash_path(context: &mut impl BuildContext, project_dir: &Path) -> io::Result<PathBuf> {
+fn get_stash_path(context: &impl BuildContext, project_dir: &Path) -> io::Result<PathBuf> {
     let canonical = context
         .files()
         .canonicalize(project_dir)
@@ -207,7 +207,7 @@ impl Project {
         }
     }
 
-    pub(crate) fn load(path: &Path, context: &mut impl BuildContext) -> Option<Self> {
+    pub(crate) fn load(path: &Path, context: &impl BuildContext) -> Option<Self> {
         let cloud_profile = context
             .read_config_file::<String>(&path.join("cloud-profile"))
             .unwrap_or_default();

--- a/gel-dsn/src/gel/project.rs
+++ b/gel-dsn/src/gel/project.rs
@@ -26,8 +26,8 @@ pub struct ProjectSearchResult {
 impl ProjectSearchResult {
     /// Find a project in the given directory.
     pub fn find(dir: ProjectDir) -> std::io::Result<Option<Self>> {
-        let mut context = BuildContextImpl::new();
-        let project = find_project_file(&mut context, dir)?;
+        let context = BuildContextImpl::new();
+        let project = find_project_file(&context, dir)?;
         Ok(project)
     }
 }
@@ -259,7 +259,7 @@ mod tests {
         context.logging.tracing = Some(traces.clone().trace_fn());
         context.config_dir = Some(vec![PathBuf::from("/home/edgedb/.config/edgedb")]);
         let res = find_project_file(
-            &mut context,
+            &context,
             ProjectDir::Search(PathBuf::from("/home/edgedb/test")),
         );
 
@@ -296,7 +296,7 @@ mod tests {
 
         // Test gel.toml only
         fs::write(&gel_path, "test1").unwrap();
-        let found = find_project_file(&mut context, ProjectDir::Search(base.to_path_buf()))
+        let found = find_project_file(&context, ProjectDir::Search(base.to_path_buf()))
             .unwrap()
             .unwrap();
         assert_eq!(found.project_path, gel_path);
@@ -304,7 +304,7 @@ mod tests {
         // Test edgedb.toml only
         fs::remove_file(&gel_path).unwrap();
         fs::write(&edgedb_path, "test2").unwrap();
-        let found = find_project_file(&mut context, ProjectDir::Search(base.to_path_buf()))
+        let found = find_project_file(&context, ProjectDir::Search(base.to_path_buf()))
             .unwrap()
             .unwrap();
         assert_eq!(found.project_path, edgedb_path);
@@ -312,7 +312,7 @@ mod tests {
         // Test both files with same content
         fs::write(&gel_path, "test3").unwrap();
         fs::write(&edgedb_path, "test3").unwrap();
-        let found = find_project_file(&mut context, ProjectDir::Search(base.to_path_buf()))
+        let found = find_project_file(&context, ProjectDir::Search(base.to_path_buf()))
             .unwrap()
             .unwrap();
         assert_eq!(found.project_path, gel_path);
@@ -320,8 +320,7 @@ mod tests {
         // Test both files with different content
         fs::write(&gel_path, "test4").unwrap();
         fs::write(&edgedb_path, "test5").unwrap();
-        let err =
-            find_project_file(&mut context, ProjectDir::Search(base.to_path_buf())).unwrap_err();
+        let err = find_project_file(&context, ProjectDir::Search(base.to_path_buf())).unwrap_err();
         assert!(err.to_string().contains("but the contents are different"));
     }
 }

--- a/gel-dsn/src/gel/stored.rs
+++ b/gel-dsn/src/gel/stored.rs
@@ -1,0 +1,207 @@
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
+
+use super::{
+    context_trace, error::ParseError, BuildContext, CredentialsFile, InstanceName,
+    DEFAULT_BRANCH_NAME, DEFAULT_DATABASE_NAME,
+};
+
+/// Read and write stored information such as [`CredentialsFile`] and [`Project`].
+#[allow(private_bounds)]
+pub struct StoredInformation<C: BuildContext> {
+    context: Arc<C>,
+}
+
+#[cfg(feature = "unstable")]
+#[allow(private_bounds)]
+impl<C: BuildContext> StoredInformation<C> {
+    pub(crate) fn new(context: C) -> Self {
+        let context = Arc::new(context);
+
+        Self { context }
+    }
+
+    pub fn credentials(&self) -> StoredCredentials<C, Arc<C>> {
+        StoredCredentials::new(self.context.clone())
+    }
+
+    pub fn stash_path(&self, path: impl AsRef<Path>) -> Result<PathBuf, std::io::Error> {
+        unimplemented!()
+    }
+}
+
+/// The persistent collection of stored credentials.
+#[allow(private_bounds)]
+pub struct StoredCredentials<CT: BuildContext, C: std::ops::Deref<Target = CT>> {
+    context: C,
+    _marker: std::marker::PhantomData<CT>,
+}
+
+#[allow(private_bounds)]
+impl<'a, CT: BuildContext> StoredCredentials<CT, &'a CT> {
+    pub(crate) fn new_ref(context: &'a CT) -> Self {
+        Self {
+            context: context,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+#[allow(private_bounds)]
+impl<CT: BuildContext, C: std::ops::Deref<Target = CT>> StoredCredentials<CT, C> {
+    pub(crate) fn new(context: C) -> Self {
+        Self {
+            context,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn list(&self) -> Result<Vec<InstanceName>, std::io::Error> {
+        let files = self.context.list_config_files("credentials/")?;
+        let mut instances = Vec::new();
+        for mut file in files {
+            if file.extension() != Some(&std::ffi::OsStr::new("json")) {
+                continue;
+            }
+            if !file.set_extension("") {
+                continue;
+            }
+            let Some(instance) = file.file_name() else {
+                context_trace!(
+                    self.context,
+                    "Skipping file without a name: {}",
+                    file.display()
+                );
+                continue;
+            };
+            let Some(s) = instance.to_str() else {
+                context_trace!(
+                    self.context,
+                    "Skipping file with non-UTF-8 name: {}",
+                    file.display()
+                );
+                continue;
+            };
+            let Ok(instance) = InstanceName::from_str(&s) else {
+                context_trace!(
+                    self.context,
+                    "Skipping file with invalid instance name: {}",
+                    file.display()
+                );
+                continue;
+            };
+            instances.push(instance);
+        }
+        Ok(instances)
+    }
+
+    /// Read the credentials for the given instance.
+    pub fn read(&self, instance: InstanceName) -> Result<Option<CredentialsFile>, ParseError> {
+        let path = format!("credentials/{instance}.json");
+        let content = self.context.read_config_file::<CredentialsFile>(&path)?;
+        if let Some(content) = &content {
+            if !content.warnings().is_empty() {
+                if let Ok(s) = serde_json::to_string(content) {
+                    if self.context.write_config_file(path, &s).is_ok() {
+                        context_trace!(self.context, "Updated out-of-date credentials");
+                    } else {
+                        context_trace!(self.context, "Failed to update credentials");
+                    }
+                } else {
+                    context_trace!(self.context, "Failed to serialize credentials");
+                }
+            }
+        }
+        Ok(content)
+    }
+
+    /// Write the credentials for the given instance.
+    fn write(
+        &self,
+        instance: InstanceName,
+        content: &CredentialsFile,
+    ) -> Result<(), std::io::Error> {
+        let mut content = content.clone();
+        // Special case: treat database=__default__ and branch=edgedb as not set
+        if content.database.as_deref() == Some(DEFAULT_DATABASE_NAME)
+            && content.branch.as_deref() == Some(DEFAULT_BRANCH_NAME)
+        {
+            content.database = None;
+            content.branch = None;
+        }
+        let path = format!("credentials/{instance}.json");
+        self.context
+            .write_config_file(path, &serde_json::to_string(&content)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gel::{Builder, CredentialsFile, InstanceName};
+    use crate::FileAccess;
+    use std::path::{Path, PathBuf};
+    use std::{collections::HashMap, sync::Mutex};
+
+    #[test]
+    fn test_list() {
+        let files = Mutex::new(HashMap::<PathBuf, String>::new());
+        let stored = Builder::default()
+            .without_system()
+            .with_env_impl(())
+            .with_fs_impl(files)
+            .with_user_impl("edgedb")
+            .with_warning(|w| println!("warning: {}", w))
+            .with_tracing(|s| println!("{}", s))
+            .stored_info();
+
+        let credentials = stored.credentials();
+        let instances = credentials.list().expect("failed to list credentials");
+        assert!(instances.is_empty());
+
+        credentials
+            .write(
+                InstanceName::Local("local".to_string()),
+                &CredentialsFile::default(),
+            )
+            .unwrap();
+        credentials
+            .write(
+                InstanceName::Local("local2".to_string()),
+                &CredentialsFile::default(),
+            )
+            .unwrap();
+
+        let instances = credentials.list().expect("failed to list credentials");
+        assert_eq!(instances.len(), 2, "expected 2 instances: {:?}", instances);
+        assert!(instances.contains(&InstanceName::Local("local".to_string())));
+        assert!(instances.contains(&InstanceName::Local("local2".to_string())));
+    }
+
+    #[test]
+    fn test_read_outdated() {
+        let files = Mutex::new(HashMap::<PathBuf, String>::new());
+        files
+            .write(
+                Path::new("/home/edgedb/.config/edgedb/credentials/local.json"),
+                "{\"tls_verify_hostname\": true}",
+            )
+            .unwrap();
+        let stored = Builder::default()
+            .without_system()
+            .with_env_impl(())
+            .with_fs_impl(files)
+            .with_user_impl("edgedb")
+            .with_warning(|w| println!("warning: {}", w))
+            .with_tracing(|s| println!("{}", s))
+            .stored_info();
+
+        let credentials = stored.credentials();
+        let content = credentials
+            .read(InstanceName::Local("local".to_string()))
+            .unwrap();
+        assert!(content.is_some());
+    }
+}

--- a/gel-dsn/src/gel/stored.rs
+++ b/gel-dsn/src/gel/stored.rs
@@ -1,8 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-    sync::Arc,
-};
+use std::{str::FromStr, sync::Arc};
 
 use super::{
     context_trace, error::ParseError, BuildContext, CredentialsFile, InstanceName,
@@ -27,10 +23,6 @@ impl<C: BuildContext> StoredInformation<C> {
     pub fn credentials(&self) -> StoredCredentials<C, Arc<C>> {
         StoredCredentials::new(self.context.clone())
     }
-
-    pub fn stash_path(&self, path: impl AsRef<Path>) -> Result<PathBuf, std::io::Error> {
-        unimplemented!()
-    }
 }
 
 /// The persistent collection of stored credentials.
@@ -44,7 +36,7 @@ pub struct StoredCredentials<CT: BuildContext, C: std::ops::Deref<Target = CT>> 
 impl<'a, CT: BuildContext> StoredCredentials<CT, &'a CT> {
     pub(crate) fn new_ref(context: &'a CT) -> Self {
         Self {
-            context: context,
+            context,
             _marker: std::marker::PhantomData,
         }
     }
@@ -63,7 +55,7 @@ impl<CT: BuildContext, C: std::ops::Deref<Target = CT>> StoredCredentials<CT, C>
         let files = self.context.list_config_files("credentials/")?;
         let mut instances = Vec::new();
         for mut file in files {
-            if file.extension() != Some(&std::ffi::OsStr::new("json")) {
+            if file.extension() != Some(std::ffi::OsStr::new("json")) {
                 continue;
             }
             if !file.set_extension("") {
@@ -85,7 +77,7 @@ impl<CT: BuildContext, C: std::ops::Deref<Target = CT>> StoredCredentials<CT, C>
                 );
                 continue;
             };
-            let Ok(instance) = InstanceName::from_str(&s) else {
+            let Ok(instance) = InstanceName::from_str(s) else {
                 context_trace!(
                     self.context,
                     "Skipping file with invalid instance name: {}",
@@ -119,7 +111,7 @@ impl<CT: BuildContext, C: std::ops::Deref<Target = CT>> StoredCredentials<CT, C>
     }
 
     /// Write the credentials for the given instance.
-    fn write(
+    pub fn write(
         &self,
         instance: InstanceName,
         content: &CredentialsFile,

--- a/gel-tokio/Cargo.toml
+++ b/gel-tokio/Cargo.toml
@@ -60,7 +60,7 @@ default = ["derive", "env"]
 derive = ["gel-derive"]
 env = ["fs"]
 admin_socket = ["dirs"]
-unstable = ["serde_json"] # features for CLI and Wasm
+unstable = ["serde_json", "gel-dsn/unstable"] # features for CLI and Wasm
 fs = ["tokio/fs", "dirs", "serde_json"]
 miette-errors = ["gel-errors/miette"]
 

--- a/gel-tokio/src/lib.rs
+++ b/gel-tokio/src/lib.rs
@@ -130,7 +130,13 @@ unstable_pub_mods! {
     mod server_params;
 }
 
+#[deprecated(note = "use `dsn` module instead")]
 pub use gel_dsn::gel::{Builder, CloudName, Config, InstanceName, TlsSecurity};
+
+/// Gel data-source name (DSN) parser and builder.
+pub mod dsn {
+    pub use gel_dsn::gel::*;
+}
 
 mod client;
 mod errors;


### PR DESCRIPTION
We currently have N paths which read and write the credentials. This creates a centralized API in gel-dsn that the CLI can use to read and write them as well.

In addition, we now remove any default branch/database settings in credential files to help prevent issues when moving between CLI versions.