### PR TITLE
Also export Host/HostType

### DIFF
--- a/gel-tokio/src/lib.rs
+++ b/gel-tokio/src/lib.rs
@@ -135,8 +135,8 @@ pub use gel_dsn::gel::{Builder, CloudName, Config, InstanceName, TlsSecurity};
 
 /// Gel data-source name (DSN) parser and builder.
 pub mod dsn {
-    pub use gel_dsn::{Host, HostType};
     pub use gel_dsn::gel::*;
+    pub use gel_dsn::{Host, HostType};
 }
 
 mod client;

--- a/gel-tokio/src/lib.rs
+++ b/gel-tokio/src/lib.rs
@@ -135,6 +135,7 @@ pub use gel_dsn::gel::{Builder, CloudName, Config, InstanceName, TlsSecurity};
 
 /// Gel data-source name (DSN) parser and builder.
 pub mod dsn {
+    pub use gel_dsn::{Host, HostType};
     pub use gel_dsn::gel::*;
 }
 


### PR DESCRIPTION
This allows downstream crates to skip a gel-dsn dependency -- we just export the whole dsn crate in a dsn submodule.