### PR TITLE
Ensure config directories are created

### DIFF
--- a/gel-dsn/src/gel/instance_name.rs
+++ b/gel-dsn/src/gel/instance_name.rs
@@ -23,7 +23,7 @@ impl From<&CloudName> for InstanceName {
 ///
 /// This is a convenience type that combines an organization name and an
 /// instance name.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CloudName {
     /// Organization name
@@ -120,7 +120,7 @@ impl CloudName {
 /// assert_eq!(format!("{}", instance), "my-org/my-instance");
 /// assert_eq!(format!("{:#}", instance), "Gel Cloud instance 'my-org/my-instance'");
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum InstanceName {
     /// Instance configured locally
     Local(String),

--- a/gel-dsn/src/user.rs
+++ b/gel-dsn/src/user.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, path::Path};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 
 pub struct SystemUserProfile;
 
@@ -34,15 +37,38 @@ impl UserProfile for &'static str {
     }
 
     fn homedir(&self) -> Option<Cow<Path>> {
-        Some(Cow::Borrowed(Path::new("/home/edgedb")))
+        Some(Cow::Owned(PathBuf::from(format!("/home/{self}"))))
     }
 
     fn config_dir(&self) -> Option<Cow<Path>> {
-        Some(Cow::Borrowed(Path::new("/home/edgedb/.config")))
+        Some(Cow::Owned(PathBuf::from(format!("/home/{self}/.config"))))
     }
 
     fn data_local_dir(&self) -> Option<Cow<Path>> {
-        Some(Cow::Borrowed(Path::new("/home/edgedb/.local")))
+        Some(Cow::Owned(PathBuf::from(format!("/home/{self}/.local"))))
+    }
+}
+
+impl UserProfile for PathBuf {
+    fn username(&self) -> Option<Cow<str>> {
+        Some(Cow::Borrowed(
+            self.file_name()
+                .expect("no file name to infer username")
+                .to_str()
+                .unwrap(),
+        ))
+    }
+
+    fn homedir(&self) -> Option<Cow<Path>> {
+        Some(Cow::Borrowed(self))
+    }
+
+    fn config_dir(&self) -> Option<Cow<Path>> {
+        Some(Cow::Owned(self.join(".config")))
+    }
+
+    fn data_local_dir(&self) -> Option<Cow<Path>> {
+        Some(Cow::Owned(self.join(".local")))
     }
 }
 


### PR DESCRIPTION
The previous credentials load/save would fail when the config directory was missing. We should treat missing config dirs as empty and automatically create directories when writing.