### PR TITLE
Defer secret key errors

### DIFF
--- a/gel-dsn/src/gel/params.rs
+++ b/gel-dsn/src/gel/params.rs
@@ -827,7 +827,10 @@ impl Params {
                             }
                         }
                     } else {
-                        return Err(ParseError::SecretKeyNotFound);
+                        // Special case: we ignore the secret key error until the final phase
+                        if phase == BuildPhase::Project {
+                            return Err(ParseError::SecretKeyNotFound);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/geldata/gel-cli/issues/1590 by normalizing the DSN phase in which we raise secret key errors in all branches. Does not change any working setups, just makes it a little easier to reason over.

Secret keys (cloud and other) have been special cased for a bit - an invalid or missing key is not raised until we've exhausted all other sources of information (args, environment, project). 

Note that this does make a previously test that was expected to fail start to pass. All secret key errors are deferred now.

