### PR TITLE
Update crate descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ docs can currently be found on docs.rs:
 
 | Crate | Source | Description |
 |-------|--------|-------------|
-| [gel-auth](https://docs.rs/gel-auth) | [Source](https://github.com/edgedb/edgedb-rust/tree/main/gel-auth) | Authentication and authorization utilities |
-| [gel-derive](https://docs.rs/gel-derive) | [Source](https://github.com/edgedb/edgedb-rust/tree/main/gel-derive) | Derive macro for data structures fetched from the database |
-| [gel-dsn](https://docs.rs/gel-dsn) | [Source](https://github.com/edgedb/edgedb-rust/tree/main/gel-dsn) | Data-source name (DSN) parser for Gel and PostgreSQL databases |
-| [gel-jwt](https://docs.rs/gel-jwt) | [Source](https://github.com/edgedb/edgedb-rust/tree/main/gel-jwt) | JSON Web Token (JWT) utilities |
-| [gel-errors](https://docs.rs/gel-errors) | [Source](https://github.com/edgedb/edgedb-rust/tree/main/gel-errors) | Error handling utilities |
-| [gel-protocol](https://docs.rs/gel-protocol) | [Source](https://github.com/edgedb/edgedb-rust/tree/main/gel-protocol) | Low-level definitions for data model of the Gel protocol |
-| [gel-stream](https://docs.rs/gel-stream) | [Source](https://github.com/edgedb/edgedb-rust/tree/main/gel-stream) | Library for streaming TLS/plaintext data between clients and servers |
-| [gel-tokio](https://docs.rs/gel-tokio) | [Source](https://github.com/edgedb/edgedb-rust/tree/main/gel-tokio) | Gel/EdgeDB client using Tokio async runtime |
+| [gel-auth](https://docs.rs/gel-auth) | [Source](./gel-auth) | Authentication and authorization for the Gel database. |
+| [gel-db-protocol](https://docs.rs/gel-db-protocol) | [Source](./gel-db-protocol) | Macros to make parsing and serializing of PostgreSQL-like protocols easier. |
+| [gel-derive](https://docs.rs/gel-derive) | [Source](./gel-derive) | Derive macros for Gel database client. |
+| [gel-dsn](https://docs.rs/gel-dsn) | [Source](./gel-dsn) | Data-source name (DSN) parser for Gel and PostgreSQL databases. |
+| [gel-errors](https://docs.rs/gel-errors) | [Source](./gel-errors) | Error types for Gel database client. |
+| [gel-jwt](https://docs.rs/gel-jwt) | [Source](./gel-jwt) | JWT implementation for the Gel database. |
+| [gel-pg-captive](https://docs.rs/gel-pg-captive) | [Source](./gel-pg-captive) | Run a captive PostgreSQL server for testing purposes. |
+| [gel-pg-protocol](https://docs.rs/gel-pg-protocol) | [Source](./gel-pg-protocol) | The Gel implementation of the PostgreSQL wire protocol. |
+| [gel-protocol](https://docs.rs/gel-protocol) | [Source](./gel-protocol) | Low-level protocol implementation for Gel database client. |
+| [gel-stream](https://docs.rs/gel-stream) | [Source](./gel-stream) | A library for streaming data between clients and servers. |
+| [gel-tokio](https://docs.rs/gel-tokio) | [Source](./gel-tokio) | Gel database client implementation for tokio. |
 
 Running Tests
 =============

--- a/gel-db-protocol/Cargo.toml
+++ b/gel-db-protocol/Cargo.toml
@@ -4,7 +4,7 @@ license = "MIT/Apache-2.0"
 version = "0.1.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2021"
-description = "A crate that makes parsing and serializing of PostgreSQL-like protocols easier"
+description = "Macros to make parsing and serializing of PostgreSQL-like protocols easier."
 readme = "README.md"
 rust-version.workspace = true
 

--- a/gel-errors/Cargo.toml
+++ b/gel-errors/Cargo.toml
@@ -4,7 +4,10 @@ license = "MIT/Apache-2.0"
 version = "0.5.2"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2018"
-description = "Error types for Gel database client. Formerly published as gel-errors."
+description = """
+Error types for Gel database client.
+Formerly published as gel-errors.
+"""
 readme = "README.md"
 rust-version.workspace = true
 

--- a/gel-pg-captive/Cargo.toml
+++ b/gel-pg-captive/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT/Apache-2.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2021"
-description = "Run a captive PostgreSQL server for testing purposes"
+description = "Run a captive PostgreSQL server for testing purposes."
 
 [lints]
 workspace = true

--- a/gel-pg-protocol/Cargo.toml
+++ b/gel-pg-protocol/Cargo.toml
@@ -4,7 +4,7 @@ license = "MIT/Apache-2.0"
 version = "0.1.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2021"
-description = "The Gel implementation of the PostgreSQL wire protocol"
+description = "The Gel implementation of the PostgreSQL wire protocol."
 readme = "README.md"
 rust-version.workspace = true
 


### PR DESCRIPTION
Clean up the crate descriptions and regenerate the table in `README.md`.

```
cargo metadata --format-version=1 | jq --raw-output '.packages.[] | select(.id | startswith("path")) | select(.publish == null) | {name: .name, description: .description | split("\n")[0] | gsub("^\\s+|\\s+$";"") } | "| [\(.name)](https://docs.rs/\(.name)) | [Source](./\(.name)) | \(.description) |"'
```
