### PR TITLE
Multi-protocol gel frontend crate [WIP]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "gel-derive",
     "gel-dsn",
     "gel-errors",
+    "gel-frontend",
     "gel-jwt",
     "gel-pg-captive",
     "gel-pg-protocol",

--- a/gel-frontend/Cargo.toml
+++ b/gel-frontend/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "gel-frontend"
+version = "0.1.0"
+edition = "2018"
+
+[features]
+python_extension = ["pyo3/serde"]
+
+[dependencies]
+pyo3.workspace = true
+tokio.workspace = true
+
+hyper = { version = "1.4.1", features = ["full"] }
+hyper-util = { version = "0.1.8", features = ["full"] }
+h2 = "0.4.6"
+tokio-openssl = "0.6.5"
+http-body-util = "0.1.2"
+tower-http = { version = "0.6.1", features = ["full"] }
+tower = { version = "0.5.1", features = ["full"] }
+pin-project = "1"
+futures = "0.3"
+scopeguard = "1"
+strum = { version = "0.26", features = ["derive"] }
+derive_more = { version = "1", features = ["full"] }
+sha1 = "0.10.6"
+base64 = "0.22.1"
+jwt = { version = "0.16", features = ["openssl"] }
+bytes = "1"
+thiserror = "1"
+hexdump = "0"
+tracing = "0"
+tracing-subscriber = "0"
+
+
+[dev-dependencies]
+rstest = "0.22.0"
+test-log = { version = "0", features = ["trace"] }
+pyo3 = { workspace = true }
+
+[lib]

--- a/gel-frontend/README.md
+++ b/gel-frontend/README.md
@@ -1,0 +1,142 @@
+## Authentication and Transports:
+
+| Auth Method | Description | Available Transports | Notes |
+|-------------|-------------|----------------------|-------|
+| Trust | Always-trust policy, disables all authentication | All | [1] |
+| SCRAM | Password-based authentication using challenge-response scheme | TCP, TCP_PG | Default for TCP and TCP_PG |
+| JWT | Uses a JWT signed by the server to authenticate | TCP, TCP_PG, HTTP, WEBSOCKET, SIMPLE_HTTP | [4] [5] |
+| Password | Simple password-based authentication over TLS | SIMPLE_HTTP | [2] |
+| mTLS | Mutual TLS authentication | All | [3] [6] |
+
+| Transport        | Description                                       | Available Auth Methods                        |
+|------------------|---------------------------------------------------|-----------------------------------------------|
+| TCP              | EdgeDB binary protocol                            | SCRAM (default), JWT[4], Trust[1], mTLS[6]    |
+| TCP_PG           | Postgres protocol for SQL query mode              | SCRAM (default), JWT[4], Trust[1], mTLS[6]    |
+| HTTP             | EdgeDB binary protocol tunneled over HTTP         | JWT[5] (default), SCRAM, Trust[1], mTLS[6]    |
+| WEBSOCKET        | EdgeDB/Postgres over WebSocket                    | JWT[5] (default), SCRAM, Trust[1], mTLS[6]    |
+| SIMPLE_HTTP      | EdgeQL over HTTP, Notebook and GraphQL endpoints  | Password[2] (default), JWT[5], Trust[1], mTLS |
+| HTTP_METRICS [7] | Metrics endpoint                                  | Trust[1] (default), mTLS[3]                   |
+| HTTP_HEALTH  [7] | Health check endpoint                             | Trust[1] (default), mTLS[3]                   |
+
+Notes:
+ - [1] Trust can be configured for any transport
+ - [2] Password is only available for SIMPLE_HTTP, where it is the default.
+   Passwords are provided using HTTP Basic auth and internally handled via
+   SCRAM.
+ - [3] Auto for HTTP_METRICS and HTTP_HEALTH will use mTLS if TLS client CA file
+   is provided, otherwise Trust
+ - [4] JWT for TCP/TCP_PG requires the token to be passed in `secret_key`
+   startup parameter
+ - [5] JWT for HTTP requires `Authorization: bearer ...`
+ - [6] mTLS for all transports other than SIMPLE_HTTP requires out-of-band
+   username
+ - [7] HTTP_METRICS and HTTP_HEALTH are configured entirely outside the database
+   and use the default auth methods
+
+## Database tenancy structure:
+
+- Tenant ID: determined by SNI
+- Database (legacy)
+- Branch
+
+Multi-tenancy requires SSL. Tenant IDs extracted from the SSL SNI information for all transports.
+
+## HTTP CORS (Cross-Origin Resource Sharing)
+
+CORS headers set by EdgeDB:
+
+- `Access-Control-Allow-Origin`: Specifies which origins are allowed to make cross-origin requests. Set to the requesting origin if it's allowed, or omitted if not.
+- `Access-Control-Expose-Headers`: Lists headers that browsers are allowed to access. Only set if specific headers are configured to be exposed.
+- `Access-Control-Allow-Methods`: Specifies the HTTP methods allowed when accessing the resource. Typically set to "GET, POST, OPTIONS" for EdgeDB endpoints.
+- `Access-Control-Allow-Headers`: Indicates which HTTP headers can be used during the actual request. Usually includes headers like "Authorization", "Content-Type", etc.
+- `Access-Control-Allow-Credentials`: When set to "true", indicates that the actual request can include user credentials (like cookies, HTTP authentication, or client-side SSL certificates).
+- `Access-Control-Max-Age`: Specifies how long the results of a preflight request can be cached. Can be used to optimize performance.
+
+- Checks for CORS configuration in the database or system config.
+- Validates the request origin against allowed origins.
+- For valid origins, sets appropriate CORS headers:
+  - `Access-Control-Allow-Origin`
+  - `Access-Control-Allow-Headers`
+      - `Authorization` for auth
+      - `Authorization`, `X-EdgeDB-User` for all paths
+  - `Access-Control-Expose-Headers`
+      - `WWW-Authenticate`, `Authentication-Info` for auth
+      - `EdgeDB-Protocol-Version` for notebook
+- For OPTIONS requests:
+  - Sets status to 204 (No Content)
+  - Adds headers:
+    - `Access-Control-Allow-Methods`
+    - `Access-Control-Allow-Headers`
+    - `Access-Control-Allow-Credentials` for extension paths
+
+## X-Forwarded-
+
+`X-Forwarded-` headers are allowed for `schema`, `port` and `host`.
+
+## HTTP Endpoints
+
+HTTP Endpoints handled internally:
+
+- /auth/token
+   - Method: GET
+   - Description: Handle authentication
+   - Request:
+     - Header: Authorization: {AUTH METHOD} data={PAYLOAD}
+   - Response:
+     - Header: www-authenticate: {AUTH METHOD} {AUTH PAYLOAD}
+     - Body: Authorization token (on successful authentication)
+
+- /auth/*
+   - Description: Additional auth extension paths
+
+- /{branch,db}/{BRANCH}
+   - Method: POST
+   - Description: Execute EdgeQL queries
+   - Request:
+     - Header: X-EdgeDB-User: {USERNAME}
+     - Header: Authorization: Bearer {TOKEN}
+     - Header: Content-Type: application/x.edgedb.v_1_0.binary
+   - Response:
+     - Content-Type: application/x.edgedb.v_1_0.binary
+     - Body: Message format as described in the protocol
+
+- /{branch,db}/{BRANCH}/edgeql
+   - Method: POST
+   - Description: Execute EdgeQL queries over HTTP
+
+- /{branch,db}/{BRANCH}/notebook
+   - Method: POST
+   - Description: Serve EdgeDB notebook protocol. This protocol does not allow for transaction commits or DDL.
+
+Additional HTTP endpoints:
+
+- /{branch,db}/{BRANCH}/graphql
+   - Method: POST
+   - Description: Execute GraphQL queries
+
+- /{branch,db}/{BRANCH}/ext/auth
+   - Method: GET, POST
+   - Description: Handle authentication extension requests
+
+- /{branch,db}/{BRANCH}/ai
+   - Method: POST
+   - Description: Handle AI-related requests
+
+- /metrics
+   - Method: GET
+   - Description: Expose metrics in OpenMetrics text format
+
+- /server-info
+   - Method: GET
+   - Description: Provide server information (only available in development or test mode)
+
+- /server/status/{ready,alive}
+   - Method: GET
+   - Description: Handles system API requests
+
+- /ui
+   - Method: GET
+   - Description: Serve the admin UI (if enabled)
+
+- /ui/_static
+   - Description: Static UI files

--- a/gel-frontend/examples/listener.rs
+++ b/gel-frontend/examples/listener.rs
@@ -1,0 +1,78 @@
+use std::{future::Future, time::Duration};
+
+use edb_frontend::config::*;
+use edb_frontend::listener::*;
+use edb_frontend::service::*;
+use edb_frontend::stream::*;
+use gel_auth::AuthType;
+use gel_auth::CredentialData;
+use hyper::Response;
+use tokio::io::AsyncReadExt;
+use tokio::io::ReadBuf;
+
+#[derive(Clone, Debug, Default)]
+struct ExampleService {}
+
+impl BabelfishService for ExampleService {
+    fn lookup_auth(
+        &self,
+        identity: ConnectionIdentity,
+        target: AuthTarget,
+    ) -> impl Future<Output = Result<CredentialData, std::io::Error>> {
+        eprintln!("lookup_auth: {:?}", identity);
+        async move {
+            Ok(CredentialData::new(
+                AuthType::Trust,
+                "matt".to_owned(),
+                "password".to_owned(),
+            ))
+        }
+    }
+
+    fn accept_stream(
+        &self,
+        identity: ConnectionIdentity,
+        language: StreamLanguage,
+        mut stream: ListenerStream,
+    ) -> impl Future<Output = Result<(), std::io::Error>> {
+        eprintln!(
+            "accept_stream: {:?}, {:?}, {:?}",
+            identity, language, stream
+        );
+        async move {
+            loop {
+                let mut buf = [0; 1024];
+                stream.read_buf(&mut ReadBuf::new(&mut buf)).await?;
+            }
+            Ok(())
+        }
+    }
+
+    fn accept_http(
+        &self,
+        identity: ConnectionIdentity,
+        req: hyper::http::Request<hyper::body::Incoming>,
+    ) -> impl Future<Output = Result<hyper::http::Response<String>, std::io::Error>> {
+        eprintln!("accept_http: {:?}, {:?}", identity, req);
+        async { Ok(Response::new("Hello!".to_string())) }
+    }
+}
+
+/// Run a test server and cconnect to it.
+fn run_test_service() {
+    let server = ExampleService::default();
+
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(async move {
+            BoundServer::bind(TestListenerConfig::new("localhost:2134"), server).unwrap();
+            loop {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        });
+}
+
+pub fn main() {
+    tracing_subscriber::fmt::init();
+    run_test_service();
+}

--- a/gel-frontend/examples/smoketest.rs
+++ b/gel-frontend/examples/smoketest.rs
@@ -1,0 +1,268 @@
+use std::{cell::RefCell, collections::HashMap, future::Future, rc::Rc};
+
+use db_proto::StructBuffer;
+use gel_stream::{client::Connector, client::Target, TlsParameters};
+use openssl::ssl::{Ssl, SslContext, SslMethod};
+use pgrust::{
+    connection::{Client, Credentials},
+    protocol::edgedb::data::{CommandComplete, ParameterStatus, StateDataDescription},
+};
+use std::pin::Pin;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpSocket,
+    task::LocalSet,
+};
+
+#[derive(Debug, Clone)]
+struct TestSetup {
+    addr: std::net::SocketAddr,
+    username: String,
+    password: String,
+    database: String,
+}
+
+trait SmokeTest {
+    fn name(&self) -> String;
+    async fn run(&self, setup: &TestSetup) -> Result<(), Box<dyn std::error::Error>>;
+}
+
+struct PostgresSelect {
+    query: String,
+    expected: String,
+}
+
+impl SmokeTest for PostgresSelect {
+    fn name(&self) -> String {
+        format!("PostgresSelect [{}]", self.query)
+    }
+
+    async fn run(&self, setup: &TestSetup) -> Result<(), Box<dyn std::error::Error>> {
+        use pgrust::protocol::postgres::data::{DataRow, ErrorResponse, RowDescription};
+
+        let target = Target::new_tcp_tls(setup.addr, TlsParameters::default());
+        let connector = Connector::new(target)?;
+
+        let credentials = Credentials {
+            username: setup.username.clone(),
+            password: setup.password.clone(),
+            database: setup.database.clone(),
+            server_settings: HashMap::new(),
+        };
+        let (client, task) = Client::new(credentials, connector);
+        tokio::task::spawn_local(task);
+        client.ready().await?;
+
+        let out = Rc::new(RefCell::new(String::new()));
+        let out_clone = out.clone();
+        client
+            .query(
+                &self.query,
+                (
+                    move |rows: RowDescription<'_>| {
+                        let cols = rows
+                            .fields()
+                            .into_iter()
+                            .map(|field| field.name().to_string_lossy().to_string())
+                            .collect::<Vec<_>>();
+                        out.borrow_mut().push_str(&format!("{}\n", cols.join(",")));
+                        let out = out.clone();
+                        move |row: DataRow<'_>| {
+                            let values: Vec<_> = row
+                                .values()
+                                .into_iter()
+                                .map(|v| v.to_string_lossy().to_string())
+                                .collect();
+                            out.borrow_mut()
+                                .push_str(&format!("{}\n", values.join(",")));
+                        }
+                    },
+                    |_: ErrorResponse<'_>| {},
+                ),
+            )
+            .await?;
+
+        let out = out_clone.borrow().clone();
+        if out == self.expected {
+            Ok(())
+        } else {
+            Err(format!("Expected `{}` but got `{}`", self.expected, out).into())
+        }
+    }
+}
+
+struct EdgeQLSelect {
+    query: String,
+    expected: String,
+}
+
+impl SmokeTest for EdgeQLSelect {
+    fn name(&self) -> String {
+        format!("EdgeQLSelect [{}]", self.query)
+    }
+
+    async fn run(&self, setup: &TestSetup) -> Result<(), Box<dyn std::error::Error>> {
+        use pgrust::protocol::edgedb::{builder, data::Data, meta};
+
+        let socket = TcpSocket::new_v4()?.connect(setup.addr).await?;
+        let mut ssl = SslContext::builder(SslMethod::tls_client())?;
+        ssl.set_alpn_protos(b"\x0dedgedb-binary")?;
+        let ssl = ssl.build();
+        let mut ssl = Ssl::new(&ssl)?;
+        ssl.set_connect_state();
+
+        let mut stream = tokio_openssl::SslStream::new(ssl, socket)?;
+        Pin::new(&mut stream).do_handshake().await?;
+
+        let handshake = builder::ClientHandshake {
+            major_ver: 2,
+            minor_ver: 0,
+            params: &[
+                builder::ConnectionParam {
+                    name: "user",
+                    value: &setup.username,
+                },
+                builder::ConnectionParam {
+                    name: "database",
+                    value: &setup.database,
+                },
+            ],
+            extensions: &[],
+        };
+        stream.write_all(&handshake.to_vec()).await?;
+
+        let execute = builder::Execute {
+            command_text: &self.query,
+            output_format: b'j',
+            expected_cardinality: b'o', // AT_MOST_ONE
+            ..Default::default()
+        };
+        stream.write_all(&execute.to_vec()).await?;
+
+        let mut buf = StructBuffer::<meta::Message>::default();
+
+        let mut done = false;
+        while !done {
+            let mut bytes = vec![0; 1024];
+            let n = stream.read(&mut bytes).await?;
+            if n == 0 {
+                break;
+            }
+            buf.push(&bytes[..n], |msg| match msg {
+                Ok(msg) => {
+                    if let Some(msg) = StateDataDescription::try_new(&msg) {
+                        eprintln!("{:?}", String::from_utf8_lossy(msg.typedesc().as_ref()));
+                    } else if let Some(msg) = ParameterStatus::try_new(&msg) {
+                        eprintln!(
+                            "{:?} {:?}",
+                            String::from_utf8_lossy(msg.name().as_ref()),
+                            String::from_utf8_lossy(msg.value().as_ref())
+                        );
+                    } else if let Some(data) = Data::try_new(&msg) {
+                        for data in data.data() {
+                            eprintln!("{:?}", data.data());
+                        }
+                    } else if CommandComplete::try_new(&msg).is_some() {
+                        done = true;
+                        return;
+                    } else {
+                        eprintln!("{} {:?}", msg.mtype() as char, msg);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                }
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[tokio::main]
+pub async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 5 {
+        println!(
+            "Usage: {} <addr:port> <username> <password> <database>",
+            args[0]
+        );
+        return;
+    }
+
+    let addr = &args[1];
+    let username = &args[2];
+    let password = &args[3];
+    let database = &args[4];
+
+    let addr = match addr.parse::<std::net::SocketAddr>() {
+        Ok(addr) => addr,
+        Err(e) => {
+            eprintln!("Invalid address format: {}", e);
+            return;
+        }
+    };
+
+    let setup = TestSetup {
+        addr,
+        username: username.to_string(),
+        password: password.to_string(),
+        database: database.to_string(),
+    };
+
+    LocalSet::new()
+        .run_until(async {
+            let mut tests: Vec<Pin<Box<dyn Future<Output = ()> + 'static>>> = vec![];
+
+            fn test(
+                setup: &TestSetup,
+                test: impl SmokeTest + 'static,
+            ) -> Pin<Box<dyn Future<Output = ()> + 'static>> {
+                let setup = setup.clone();
+                Box::pin(async move {
+                    let name = test.name();
+                    let res = test.run(&setup).await;
+                    match res {
+                        Ok(_) => println!("✅ {name} passed"),
+                        Err(e) => println!("❌ {name} failed: {}", e),
+                    };
+                })
+            }
+
+            tests.push(test(
+                &setup,
+                PostgresSelect {
+                    query: "SELECT".to_string(),
+                    expected: "\n\n".to_string(),
+                },
+            ));
+            tests.push(test(
+                &setup,
+                PostgresSelect {
+                    query: "SELECT 1 as x".to_string(),
+                    expected: "x\n1\n".to_string(),
+                },
+            ));
+            tests.push(test(
+                &setup,
+                PostgresSelect {
+                    query: "SELECT LIMIT 0".to_string(),
+                    expected: "\n".to_string(),
+                },
+            ));
+            tests.push(test(
+                &setup,
+                EdgeQLSelect {
+                    query: "select 1".to_string(),
+                    expected: "1\n".to_string(),
+                },
+            ));
+
+            for test in tests {
+                test.await;
+            }
+        })
+        .await;
+}

--- a/gel-frontend/src/config.rs
+++ b/gel-frontend/src/config.rs
@@ -1,0 +1,200 @@
+use futures::{stream, Stream, StreamExt};
+use std::{
+    hash::Hash,
+    net::{SocketAddr, ToSocketAddrs},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    stream::{StreamProperties, TransportType},
+    stream_type::StreamType,
+};
+
+#[derive(Clone, Debug, derive_more::From)]
+pub enum ListenerAddress {
+    Tcp(SocketAddr),
+    #[cfg(unix)]
+    Unix(Arc<std::os::unix::net::SocketAddr>),
+}
+
+impl ListenerAddress {
+    pub fn tcp_addr(&self) -> Option<SocketAddr> {
+        match self {
+            ListenerAddress::Tcp(addr) => Some(*addr),
+            #[cfg(unix)]
+            ListenerAddress::Unix(_) => None,
+        }
+    }
+}
+
+impl Hash for ListenerAddress {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            ListenerAddress::Tcp(x) => x.hash(state),
+            ListenerAddress::Unix(x) => format!("{x:?}").hash(state),
+        }
+    }
+}
+
+impl Eq for ListenerAddress {}
+impl PartialEq for ListenerAddress {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ListenerAddress::Tcp(x), ListenerAddress::Tcp(y)) => x.eq(y),
+            (ListenerAddress::Unix(x), ListenerAddress::Unix(y)) => {
+                format!("{x:?}").eq(&format!("{y:?}"))
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Implemented by the embedder to configure the live state of the listener.
+pub trait ListenerConfig: std::fmt::Debug + Send + Sync + 'static {
+    /// Returns a stream of [`ListenerAddress`]es, allowing the server to
+    /// reconfigure the listening port at any time.
+    fn listen_address(&self) -> impl Stream<Item = std::io::Result<Vec<ListenerAddress>>> + Send;
+
+    /// Process the SSL SNI, returning the SSL configuration and an optional tenant ID.
+    fn ssl_config_sni(&self, hostname: Option<&str>) -> Result<(SslConfig, Option<String>), ()>;
+
+    fn jwt_key(&self)
+        -> Result<jwt::algorithm::openssl::PKeyWithDigest<openssl::pkey::Public>, ()>;
+
+    /// Returns true if the given [`StreamType`] is supported at this
+    /// time.
+    fn is_supported(
+        &self,
+        stream_type: Option<StreamType>,
+        transport_type: TransportType,
+        stream_props: &StreamProperties,
+    ) -> bool;
+}
+
+pub struct SslConfig {
+    inner: Arc<Mutex<SslConfigInner>>,
+}
+
+impl SslConfig {
+    pub fn new(cert: PathBuf, key: PathBuf) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SslConfigInner::Unconfigured { cert, key })),
+        }
+    }
+    pub(crate) fn maybe_configure(
+        &self,
+        f: impl FnOnce(&mut openssl::ssl::SslContextBuilder),
+    ) -> openssl::ssl::SslContext {
+        let mut inner = self.inner.lock().unwrap();
+        match &mut *inner {
+            SslConfigInner::Unconfigured { cert, key } => {
+                use openssl::pkey::PKey;
+                use openssl::ssl::SslContext;
+                use openssl::x509::X509;
+                use std::fs::File;
+                use std::io::Read;
+
+                let mut ctx_builder = SslContext::builder(openssl::ssl::SslMethod::tls()).unwrap();
+
+                // Load the certificate
+                let mut cert_file = File::open(cert).unwrap();
+                let mut cert_contents = Vec::new();
+                cert_file.read_to_end(&mut cert_contents).unwrap();
+                let cert = X509::from_pem(&cert_contents).unwrap();
+                ctx_builder.set_certificate(&cert).unwrap();
+
+                // Load the private key
+                let mut key_file = File::open(key).unwrap();
+                let mut key_contents = Vec::new();
+                key_file.read_to_end(&mut key_contents).unwrap();
+                let key = PKey::private_key_from_pem(&key_contents).unwrap();
+                ctx_builder.set_private_key(&key).unwrap();
+
+                // Apply any additional configuration
+                f(&mut ctx_builder);
+
+                // Build the context and update the inner state
+                let context = ctx_builder.build();
+                *inner = SslConfigInner::Configured {
+                    context: context.clone(),
+                };
+                context
+            }
+            SslConfigInner::Configured { context } => context.clone(),
+        }
+    }
+}
+
+enum SslConfigInner {
+    Unconfigured { cert: PathBuf, key: PathBuf },
+    Configured { context: openssl::ssl::SslContext },
+}
+
+#[derive(Debug)]
+pub struct TestListenerConfig {
+    addrs: Vec<SocketAddr>,
+}
+
+impl TestListenerConfig {
+    pub fn new(s: impl ToSocketAddrs) -> Self {
+        let addrs = s.to_socket_addrs().unwrap().collect();
+        Self { addrs }
+    }
+}
+
+const MOCK_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgwT5cQa55iRfc/q7I
+uHXWqSw0enO7zQUhbSxj1G8cVfGhRANCAAT/ROscvp1DCIhbA8mbcpQupILxEUVq
+f4r3nlQZCrteNogGAnV+IC2sCGjZuK9xknSMXT7EFkmNkCmTqPeaJKjv
+-----END PRIVATE KEY-----"#;
+
+fn mock_key_private() -> openssl::pkey::PKey<openssl::pkey::Private> {
+    openssl::pkey::PKey::private_key_from_pem(MOCK_KEY.as_bytes()).unwrap()
+}
+
+fn mock_key_public() -> openssl::pkey::PKey<openssl::pkey::Public> {
+    openssl::pkey::PKey::public_key_from_pem(MOCK_KEY.as_bytes()).unwrap()
+}
+
+impl ListenerConfig for TestListenerConfig {
+    fn is_supported(
+        &self,
+        stream_type: Option<StreamType>,
+        transport_type: TransportType,
+        stream_props: &StreamProperties,
+    ) -> bool {
+        eprintln!("is_supported? stream_type={stream_type:?} transport_type={transport_type:?} stream_props={stream_props:?}");
+        true
+    }
+
+    fn jwt_key(&self) -> Result<jwt::PKeyWithDigest<openssl::pkey::Public>, ()> {
+        let key = mock_key_public();
+        Ok(jwt::PKeyWithDigest {
+            digest: openssl::hash::MessageDigest::sha256(),
+            key,
+        })
+    }
+
+    fn ssl_config_sni(&self, hostname: Option<&str>) -> Result<(SslConfig, Option<String>), ()> {
+        let package_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+        let cert_path = Path::new(&package_root).join("../../tests/certs/server.cert.pem");
+        let key_path = Path::new(&package_root).join("../../tests/certs/server.key.pem");
+
+        let ssl_config = SslConfig::new(cert_path, key_path);
+
+        Ok((ssl_config, None))
+    }
+
+    fn listen_address(&self) -> impl Stream<Item = std::io::Result<Vec<ListenerAddress>>> {
+        let addrs = self
+            .addrs
+            .iter()
+            .map(|addr| ListenerAddress::Tcp(*addr))
+            .collect();
+        stream::select_all(vec![
+            stream::once(async { Ok(addrs) }).boxed(),
+            stream::pending().boxed(),
+        ])
+    }
+}

--- a/gel-frontend/src/hyper.rs
+++ b/gel-frontend/src/hyper.rs
@@ -1,0 +1,252 @@
+use hyper::{
+    body::{Body, Buf, Bytes},
+    upgrade::Upgraded,
+};
+use hyper_util::rt::TokioIo;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::config::ListenerAddress;
+
+/// A stream that wraps a [hyper::upgrade::Upgraded].
+pub struct HyperUpgradedStream {
+    inner: TokioIo<Upgraded>,
+}
+
+impl HyperUpgradedStream {
+    pub fn new(upgraded: Upgraded) -> Self {
+        HyperUpgradedStream {
+            inner: TokioIo::new(upgraded),
+        }
+    }
+}
+
+impl AsyncRead for HyperUpgradedStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for HyperUpgradedStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.get_mut().inner).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}
+
+/// A stream that wraps a `hyper::body::Incoming` for reads, and provides
+/// an mpsc channel of frames (bounded) for writes for a response body.
+///
+/// Note that an HTTP/1.x and HTTP/2 request/response pair _might_ be
+/// technically duplex but we explicitly convert them to simplex here
+/// because we cannot guarantee that a middleware box hasn't tampered with
+/// the state.
+pub struct HyperStream {
+    state: StreamState,
+    response_body_rx: tokio::sync::mpsc::Receiver<Bytes>,
+    pub(crate) local_addr: ListenerAddress,
+    pub(crate) peer_addr: ListenerAddress,
+}
+
+enum StreamState {
+    Reading {
+        incoming: hyper::body::Incoming,
+        partial_frame: hyper::body::Bytes,
+        response_body_tx: tokio::sync::mpsc::Sender<Bytes>,
+    },
+    Writing(tokio::sync::mpsc::Sender<Bytes>),
+    Shutdown,
+}
+
+impl HyperStream {
+    pub fn new(
+        incoming: hyper::body::Incoming,
+        local_addr: ListenerAddress,
+        peer_addr: ListenerAddress,
+    ) -> Self {
+        let (response_body_tx, response_body_rx) = tokio::sync::mpsc::channel(10); // Adjust buffer size as needed
+        HyperStream {
+            state: StreamState::Reading {
+                incoming,
+                partial_frame: Bytes::new(),
+                response_body_tx,
+            },
+            response_body_rx,
+            local_addr,
+            peer_addr,
+        }
+    }
+}
+
+impl AsyncRead for HyperStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+
+        match &mut this.state {
+            StreamState::Reading {
+                incoming,
+                partial_frame,
+                ..
+            } => {
+                // If there are any partial bytes, copy them to the buffer first
+                if !partial_frame.is_empty() {
+                    let len = std::cmp::min(partial_frame.len(), buf.remaining());
+                    buf.put_slice(&partial_frame[..len]);
+                    partial_frame.advance(len);
+                    if partial_frame.is_empty() {
+                        *partial_frame = Bytes::new();
+                    }
+                    return Poll::Ready(Ok(()));
+                }
+
+                loop {
+                    // Read from the incoming stream
+                    break match Pin::new(&mut *incoming).poll_frame(cx) {
+                        Poll::Ready(Some(Ok(mut data))) => {
+                            // Ignore trailers
+                            let Some(data) = data.data_mut() else {
+                                continue;
+                            };
+                            let len = std::cmp::min(data.len(), buf.remaining());
+                            buf.put_slice(&data[..len]);
+                            if len < data.len() {
+                                *partial_frame = data.slice(len..);
+                            }
+                            Poll::Ready(Ok(()))
+                        }
+                        Poll::Ready(Some(Err(e))) => {
+                            Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::Other, e)))
+                        }
+                        Poll::Ready(None) => Poll::Ready(Ok(())),
+                        Poll::Pending => Poll::Pending,
+                    };
+                }
+            }
+            StreamState::Writing(_) | StreamState::Shutdown => {
+                Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "Stream is in writing or shutdown state",
+                )))
+            }
+        }
+    }
+}
+
+impl tokio::io::AsyncWrite for HyperStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        loop {
+            break match &mut this.state {
+                StreamState::Reading {
+                    response_body_tx, ..
+                } => {
+                    // Transition to Writing state
+                    let tx = response_body_tx.clone();
+                    this.state = StreamState::Writing(tx);
+                    // Fall through to Writing case
+                    continue;
+                }
+                StreamState::Writing(outgoing) => {
+                    match outgoing.try_send(Bytes::copy_from_slice(buf)) {
+                        Ok(_) => Poll::Ready(Ok(buf.len())),
+                        // **** NOCOMMIT **** This is wrong!
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                            todo!("This need to register the waker!")
+                        }
+                        Err(e) => {
+                            Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::Other, e)))
+                        }
+                    }
+                }
+                StreamState::Shutdown => Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "Stream has been shut down",
+                ))),
+            };
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        match &this.state {
+            StreamState::Writing(outgoing) => {
+                // **** NOCOMMIT **** This is wrong!
+                todo!("This need to register the waker!");
+            }
+            StreamState::Reading { .. } => Poll::Ready(Ok(())),
+            StreamState::Shutdown => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "Stream has been shut down",
+            ))),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        this.state = StreamState::Shutdown;
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl hyper::body::Body for HyperStream {
+    type Data = hyper::body::Bytes;
+    type Error = std::io::Error;
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        this.response_body_rx
+            .poll_recv(cx)
+            .map(|option| option.map(|bytes| Ok(hyper::body::Frame::data(bytes))))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.response_body_rx.is_closed()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        hyper::body::SizeHint::default()
+    }
+}

--- a/gel-frontend/src/lib.rs
+++ b/gel-frontend/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod config;
+pub mod hyper;
+pub mod listener;
+pub mod service;
+pub mod stream;
+pub mod stream_type;
+pub mod tower;
+
+#[cfg(feature = "python_extension")]
+pub mod python;

--- a/gel-frontend/src/listener.rs
+++ b/gel-frontend/src/listener.rs
@@ -1,0 +1,1223 @@
+#![doc = "../README.md"]
+
+use crate::{
+    config::ListenerAddress,
+    hyper::HyperUpgradedStream,
+    service::{AuthTarget, BabelfishService, ConnectionIdentityBuilder, StreamLanguage},
+    stream::{ListenerStream, StreamProperties, StreamPropertiesBuilder, TransportType},
+    stream_type::{
+        identify_stream, negotiate_alpn, negotiate_ws_protocol, PostgresInitialMessage,
+        StreamState, StreamType, UnknownStreamType,
+    },
+};
+use futures::StreamExt;
+use hyper::{upgrade::OnUpgrade, Request, Response, StatusCode};
+use openssl::ssl::{AlpnError, NameType, SniError, Ssl, SslAlert, SslContext, SslMethod};
+use scopeguard::defer;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    OnceLock,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    hash::RandomState,
+    io::ErrorKind,
+    iter::FromIterator,
+    pin::{pin, Pin},
+    sync::{Arc, Mutex},
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, UnixListener, UnixStream},
+};
+use tracing::{error, info, trace, warn};
+
+use crate::config::ListenerConfig;
+
+struct SSLExData {
+    identity: ConnectionIdentityBuilder,
+    stream_props: Arc<StreamProperties>,
+}
+
+static SSL_EX_DATA_INDEX: OnceLock<openssl::ex_data::Index<Ssl, SSLExData>> = OnceLock::new();
+
+fn get_ssl_ex_data_index() -> openssl::ex_data::Index<Ssl, SSLExData> {
+    *SSL_EX_DATA_INDEX
+        .get_or_init(|| Ssl::new_ex_index().expect("Failed to create SSL ex_data index"))
+}
+
+async fn handle_ws_upgrade_http1(
+    stream_props: Arc<StreamProperties>,
+    identity: ConnectionIdentityBuilder,
+    mut req: Request<hyper::body::Incoming>,
+    bound_config: impl IsBoundConfig,
+) -> Result<Response<String>, std::io::Error> {
+    let mut stream_props = StreamProperties {
+        parent: Some(stream_props),
+        http_version: Some(req.version()),
+        ..StreamProperties::new(TransportType::WebSocket)
+    };
+
+    let mut ws_key = None;
+    let mut ws_version = None;
+    let mut ws_protocol = None;
+
+    if let Some(upgrade) = req.headers().get(hyper::header::UPGRADE) {
+        if upgrade.as_bytes().eq_ignore_ascii_case(b"websocket") {
+            ws_key = req
+                .headers()
+                .get(hyper::header::SEC_WEBSOCKET_KEY)
+                .map(|v| v.to_str().unwrap_or("").to_string());
+            ws_version = req
+                .headers()
+                .get(hyper::header::SEC_WEBSOCKET_VERSION)
+                .map(|v| v.to_str().unwrap_or("").to_string());
+            ws_protocol = req
+                .headers()
+                .get(hyper::header::SEC_WEBSOCKET_PROTOCOL)
+                .map(|v| v.to_str().unwrap_or("").to_string());
+        }
+    }
+
+    stream_props.request_headers = Some(std::mem::take(req.headers_mut()));
+
+    if let (Some(key), Some(version)) = (ws_key, ws_version) {
+        trace!("WebSocket upgrade request detected:");
+        trace!("  Key: {}", key);
+        trace!("  Version: {}", version);
+        if let Some(protocol) = &ws_protocol {
+            trace!("  Protocol: {}", protocol);
+            stream_props.protocol =
+                negotiate_ws_protocol(bound_config.config().as_ref(), protocol, &stream_props);
+        }
+
+        if stream_props.protocol.is_none() {
+            return Ok(Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .body("Invalid WebSocket upgrade request".to_string())
+                .unwrap());
+        }
+
+        tokio::task::spawn(async move {
+            if let Ok(upgraded) = hyper::upgrade::on(req).await {
+                let stream =
+                    ListenerStream::new_websocket(stream_props, HyperUpgradedStream::new(upgraded));
+                if let Err(err) = handle_ws_upgrade(stream, identity, bound_config).await {
+                    error!("WebSocket task failed {err:?}");
+                }
+            }
+        });
+
+        Ok(Response::builder()
+            .status(StatusCode::SWITCHING_PROTOCOLS)
+            .header(hyper::header::UPGRADE, "websocket")
+            .header(hyper::header::CONNECTION, "Upgrade")
+            .header(
+                hyper::header::SEC_WEBSOCKET_ACCEPT,
+                generate_ws_accept(&key),
+            )
+            .body("Switching to WebSocket".to_string())
+            .unwrap())
+    } else {
+        Ok(Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body("Invalid WebSocket upgrade request".to_string())
+            .unwrap())
+    }
+}
+
+fn generate_ws_accept(key: &str) -> String {
+    use base64::{engine::general_purpose, Engine as _};
+    use sha1::{Digest, Sha1};
+
+    let mut sha1 = Sha1::new();
+    sha1.update(key.as_bytes());
+    sha1.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    let result = sha1.finalize();
+    general_purpose::STANDARD.encode(result)
+}
+
+async fn handle_ws_upgrade_http2(
+    stream_props: Arc<StreamProperties>,
+    identity: ConnectionIdentityBuilder,
+    mut req: Request<hyper::body::Incoming>,
+    bound_config: impl IsBoundConfig,
+) -> Result<Response<String>, std::io::Error> {
+    let mut stream_props = StreamProperties {
+        parent: Some(stream_props),
+        http_version: Some(req.version()),
+        ..StreamProperties::new(TransportType::WebSocket)
+    };
+    if let Some(protocol) = req.extensions().get::<hyper::ext::Protocol>() {
+        if protocol.as_str().eq_ignore_ascii_case("websocket") {
+            let ws_version = req
+                .headers()
+                .get(hyper::header::SEC_WEBSOCKET_VERSION)
+                .map(|v| v.to_str().unwrap_or("").to_string());
+            let ws_protocol = req
+                .headers()
+                .get(hyper::header::SEC_WEBSOCKET_PROTOCOL)
+                .map(|v| v.to_str().unwrap_or("").to_string());
+            stream_props.request_headers = Some(std::mem::take(req.headers_mut()));
+
+            if let Some(version) = ws_version {
+                trace!("HTTP/2 WebSocket upgrade request detected:");
+                trace!("  Version: {}", version);
+                if let Some(protocol) = &ws_protocol {
+                    trace!("  Protocol: {}", protocol);
+                    stream_props.protocol = negotiate_ws_protocol(
+                        bound_config.config().as_ref(),
+                        protocol,
+                        &stream_props,
+                    );
+                }
+            }
+
+            if stream_props.protocol.is_none() {
+                return Ok(Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .body("Invalid WebSocket upgrade request".to_string())
+                    .unwrap());
+            }
+
+            tokio::task::spawn(async move {
+                if let Ok(upgraded) = hyper::upgrade::on(req).await {
+                    let stream = ListenerStream::new_websocket(
+                        stream_props,
+                        HyperUpgradedStream::new(upgraded),
+                    );
+                    handle_ws_upgrade(stream, identity, bound_config).await;
+                }
+            });
+
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .body("Switching to WebSocket".to_string())
+                .unwrap())
+        } else {
+            Ok(Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body("Invalid WebSocket protocol".to_string())
+                .unwrap())
+        }
+    } else {
+        Ok(Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body("Missing protocol extension".to_string())
+            .unwrap())
+    }
+}
+
+async fn handle_ws_upgrade(
+    stream: ListenerStream,
+    identity: ConnectionIdentityBuilder,
+    bound_config: impl IsBoundConfig,
+) -> Result<(), std::io::Error> {
+    handle_connection_inner(StreamState::Encapsulated, stream, identity, bound_config).await
+}
+
+struct HttpService<T: IsBoundConfig> {
+    bound_config: T,
+    stream_props: Arc<StreamProperties>,
+    identity: ConnectionIdentityBuilder,
+}
+
+impl<T: IsBoundConfig> HttpService<T> {
+    pub fn new(
+        bound_config: T,
+        stream_props: Arc<StreamProperties>,
+        identity: ConnectionIdentityBuilder,
+    ) -> Self {
+        Self {
+            bound_config,
+            stream_props,
+            identity,
+        }
+    }
+}
+
+impl<T: IsBoundConfig> hyper::service::Service<Request<hyper::body::Incoming>> for HttpService<T> {
+    type Error = std::io::Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Response<String>, std::io::Error>> + Send + Sync>>;
+    type Response = Response<String>;
+
+    fn call(&self, req: Request<hyper::body::Incoming>) -> Self::Future {
+        let bound_config = self.bound_config.clone();
+        let stream_props = self.stream_props.clone();
+        let identity = self.identity.new_builder();
+        Box::pin(async move {
+            // First, check for invalid URI segments. The server will require fully-normalized paths.
+            let uri = req.uri();
+            if uri.path()[1..]
+                .split('/')
+                .any(|segment| segment == "." || segment == ".." || segment.is_empty())
+            {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body("Invalid request: URI contains invalid segments".to_string())
+                    .unwrap());
+            }
+
+            req.headers().get("x-edgedb-user");
+
+            if req.extensions().get::<OnUpgrade>().is_some() {
+                match req.version() {
+                    hyper::Version::HTTP_11 => {
+                        return handle_ws_upgrade_http1(stream_props, identity, req, bound_config)
+                            .await;
+                    }
+                    hyper::Version::HTTP_2 => {
+                        return handle_ws_upgrade_http2(stream_props, identity, req, bound_config)
+                            .await;
+                    }
+                    _ => {
+                        return Ok(Response::builder()
+                            .status(StatusCode::HTTP_VERSION_NOT_SUPPORTED)
+                            .body("Unsupported HTTP version".to_string())
+                            .unwrap());
+                    }
+                }
+            }
+
+            if uri.path().starts_with("/db/") || uri.path().starts_with("/branch/") {
+                let mut split = uri.path().split('/');
+                split.next();
+                if let Some(branch_or_db) = split.next() {
+                    if split.next().is_none() {}
+                }
+            }
+
+            Ok::<_, std::io::Error>(Response::new("Hello!".to_owned()))
+        })
+    }
+}
+
+/// Handles a connection from the listener. This method will not return until the connection is closed.
+async fn handle_connection_inner(
+    state: StreamState,
+    mut socket: ListenerStream,
+    identity: ConnectionIdentityBuilder,
+    bound_config: impl IsBoundConfig,
+) -> Result<(), std::io::Error> {
+    trace!("handle_connection_inner state={state:?} {socket:?}");
+    let res = identify_stream(state, &mut socket).await;
+    let stream_type = match res {
+        Ok(stream_type) => stream_type,
+        Err(unknown_type) => return handle_stream_unknown(unknown_type, socket).await,
+    };
+
+    let transport = socket.transport_type();
+    if !bound_config.config().is_supported(
+        Some(stream_type),
+        socket.transport_type(),
+        socket.props(),
+    ) {
+        warn!("{stream_type:?} on {transport:?} disabled");
+        _ = socket.write_all(stream_type.go_away_message()).await;
+        _ = socket.shutdown().await;
+        return Ok(());
+    }
+
+    match stream_type {
+        StreamType::EdgeDBBinary => {
+            handle_stream_edgedb_binary(socket, identity, bound_config).await
+        }
+        StreamType::HTTP1x => handle_stream_http1x(socket, identity, bound_config).await,
+        StreamType::HTTP2 => handle_stream_http2(socket, identity, bound_config).await,
+        StreamType::SSLTLS => handle_stream_ssltls(socket, identity, bound_config).await,
+        StreamType::PostgresInitial(PostgresInitialMessage::SSLRequest) => {
+            handle_stream_postgres_ssl(socket, identity, bound_config).await
+        }
+        StreamType::PostgresInitial(..) => {
+            handle_stream_postgres_initial(socket, identity, bound_config).await
+        }
+    }
+}
+
+async fn handle_stream_unknown(
+    unknown_type: UnknownStreamType,
+    mut socket: ListenerStream,
+) -> Result<(), std::io::Error> {
+    _ = socket.write_all(unknown_type.go_away_message()).await;
+    _ = socket.shutdown().await;
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        format!("Invalid protocol ({unknown_type:?})"),
+    ))
+}
+
+async fn handle_stream_edgedb_binary(
+    mut socket: ListenerStream,
+    identity: ConnectionIdentityBuilder,
+    bound_config: impl IsBoundConfig,
+) -> Result<(), std::io::Error> {
+    use pgrust::{
+        errors::edgedb::EdbError,
+        handshake::edgedb_server::{ConnectionDrive, ConnectionEvent, ServerState},
+    };
+
+    let mut resolved_identity = None;
+    let mut server_state = ServerState::default();
+    let mut startup_params = HashMap::with_capacity(16);
+    let send_buf = Mutex::new(bytes::BytesMut::new());
+    let auth_ready = AtomicBool::new(false);
+    let params_ready = AtomicBool::new(false);
+    let mut update = |update: ConnectionEvent<'_>| {
+        use ConnectionEvent::*;
+        trace!("UPDATE: {update:?}");
+        match update {
+            Auth(user, database, branch) => {
+                identity.set_branch(branch);
+                identity.set_database(database);
+                identity.set_user(user);
+                auth_ready.store(true, Ordering::SeqCst);
+            }
+            Parameter(name, value) => {
+                startup_params.insert(name.to_owned(), value.to_owned());
+            }
+            Params => params_ready.store(true, Ordering::SeqCst),
+            Send(bytes) => {
+                // TODO: Reduce copies and allocations here
+                send_buf.lock().unwrap().extend_from_slice(&bytes.to_vec());
+            }
+            ServerError(e) => {
+                trace!("ERROR {e:?}");
+            }
+            StateChanged(..) => {}
+        }
+        Ok(())
+    };
+
+    while !server_state.is_done() || !send_buf.lock().unwrap().is_empty() {
+        let send_buf = std::mem::take(&mut *send_buf.lock().unwrap());
+        if !send_buf.is_empty() {
+            eprintln!("Sending {send_buf:?}");
+            socket.write_all(&send_buf).await?;
+        } else if auth_ready.swap(false, Ordering::SeqCst) {
+            let built = match identity.clone().build() {
+                Ok(built) => built,
+                Err(e) => {
+                    server_state
+                        .drive(
+                            ConnectionDrive::Fail(
+                                EdbError::AuthenticationError,
+                                "Missing database or user",
+                            ),
+                            &mut update,
+                        )
+                        .unwrap();
+                    return Ok(());
+                }
+            };
+            resolved_identity = Some(built);
+            let auth = bound_config
+                .service()
+                .lookup_auth(
+                    resolved_identity.clone().unwrap(),
+                    AuthTarget::Stream(StreamLanguage::Postgres),
+                )
+                .await?;
+            server_state
+                .drive(
+                    ConnectionDrive::AuthInfo(auth.auth_type(), auth),
+                    &mut update,
+                )
+                .unwrap();
+        } else if params_ready.swap(false, Ordering::SeqCst) {
+            server_state
+                .drive(ConnectionDrive::Ready(Default::default()), &mut update)
+                .unwrap();
+        } else {
+            let mut b = [0; 512];
+            let n = socket.read(&mut b).await?;
+            if n == 0 {
+                // EOF
+                return Ok(());
+            }
+            let res = server_state.drive(ConnectionDrive::RawMessage(&b[..n]), &mut update);
+            if res.is_err() {
+                // TODO?
+                error!("{res:?}");
+                return Ok(());
+            }
+        }
+    }
+
+    let socket = socket.upgrade(StreamPropertiesBuilder {
+        stream_params: Some(startup_params),
+        ..Default::default()
+    });
+    bound_config
+        .service()
+        .accept_stream(resolved_identity.unwrap(), StreamLanguage::EdgeDB, socket)
+        .await;
+
+    Ok(())
+}
+
+async fn handle_stream_http1x(
+    socket: ListenerStream,
+    identity: ConnectionIdentityBuilder,
+    bound_config: impl IsBoundConfig,
+) -> Result<(), std::io::Error> {
+    let http1 = hyper::server::conn::http1::Builder::new();
+    let props = socket.props_clone();
+    let conn = http1.serve_connection(
+        hyper_util::rt::TokioIo::new(socket),
+        HttpService::new(bound_config, props, identity),
+    );
+    conn.with_upgrades()
+        .await
+        .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e))
+}
+
+async fn handle_stream_http2(
+    socket: ListenerStream,
+    identity: ConnectionIdentityBuilder,
+    bound_config: impl IsBoundConfig,
+) -> Result<(), std::io::Error> {
+    let mut http2 = hyper::server::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new());
+    http2.enable_connect_protocol();
+    let props = socket.props_clone();
+    let conn = http2.serve_connection(
+        hyper_util::rt::TokioIo::new(socket),
+        HttpService::new(bound_config, props, identity),
+    );
+    tokio::task::spawn(conn)
+        .await?
+        .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e))
+}
+
+async fn handle_stream_ssltls(
+    socket: ListenerStream,
+    identity: ConnectionIdentityBuilder,
+    bound_config: impl IsBoundConfig,
+) -> Result<(), std::io::Error> {
+    let mut ssl = bound_config.ssl()?;
+    ssl.set_ex_data(
+        get_ssl_ex_data_index(),
+        SSLExData {
+            identity: identity.clone(),
+            stream_props: socket.props_clone(),
+        },
+    );
+    let ssl_socket = socket.start_ssl(ssl).await?;
+    Box::pin(handle_connection_inner(
+        StreamState::Ssl,
+        ssl_socket,
+        identity,
+        bound_config,
+    ))
+    .await
+}
+
+async fn handle_stream_postgres_ssl(
+    mut socket: ListenerStream,
+    identity: ConnectionIdentityBuilder,
+    bound_config: impl IsBoundConfig,
+) -> Result<(), std::io::Error> {
+    let mut buf = [0; 8];
+    socket.read_exact(&mut buf).await;
+
+    // Postgres checks to see if the socket is readable and fails here
+    let peek = [0; 1];
+    // let len = socket.peek(&mut peek).await?;
+    // if len != 0 {
+    //     return Err(std::io::Error::new(
+    //         std::io::ErrorKind::InvalidData,
+    //         "Invalid SSL handshake",
+    //     ));
+    // }
+
+    if !bound_config.config().is_supported(
+        Some(StreamType::PostgresInitial(
+            PostgresInitialMessage::StartupMessage,
+        )),
+        TransportType::Ssl,
+        socket.props(),
+    ) {
+        socket.write_all(b"N").await?;
+        return Box::pin(handle_connection_inner(
+            StreamState::PgSslUpgrade,
+            socket,
+            identity,
+            bound_config,
+        ))
+        .await;
+    }
+
+    eprintln!("Booting postgres SSL");
+    socket.write_all(b"S").await?;
+    let mut ssl = bound_config.ssl()?;
+    ssl.set_ex_data(
+        get_ssl_ex_data_index(),
+        SSLExData {
+            identity: identity.clone(),
+            stream_props: socket.props_clone(),
+        },
+    );
+
+    let ssl_socket = socket.start_ssl(ssl).await?;
+    Box::pin(handle_connection_inner(
+        StreamState::PgSslUpgrade,
+        ssl_socket,
+        identity,
+        bound_config,
+    ))
+    .await
+}
+
+async fn handle_stream_postgres_initial(
+    mut socket: ListenerStream,
+    identity: ConnectionIdentityBuilder,
+    bound_config: impl IsBoundConfig,
+) -> Result<(), std::io::Error> {
+    use pgrust::{
+        errors::{PgError, PgErrorInvalidAuthorizationSpecification},
+        handshake::{
+            server::{ConnectionDrive, ConnectionEvent, ServerState},
+            ConnectionSslRequirement,
+        },
+    };
+
+    let mut resolved_identity = None;
+    let mut server_state = ServerState::new(ConnectionSslRequirement::Disable);
+    let mut startup_params = HashMap::with_capacity(16);
+    let send_buf = Mutex::new(bytes::BytesMut::new());
+    let auth_ready = AtomicBool::new(false);
+    let params_ready = AtomicBool::new(false);
+    let mut update = |update: ConnectionEvent<'_>| {
+        use ConnectionEvent::*;
+        trace!("UPDATE: {update:?}");
+        match update {
+            Auth(user, database) => {
+                identity.set_pg_database(database);
+                identity.set_user(user);
+                auth_ready.store(true, Ordering::SeqCst);
+            }
+            Parameter(name, value) => {
+                startup_params.insert(name.to_owned(), value.to_owned());
+            }
+            Params => params_ready.store(true, Ordering::SeqCst),
+            Send(bytes) => {
+                // TODO: Reduce copies and allocations here
+                send_buf.lock().unwrap().extend_from_slice(&bytes.to_vec());
+            }
+            SendSSL(..) => unreachable!(),
+            ServerError(e) => {
+                trace!("ERROR {e:?}");
+            }
+            StateChanged(..) => {}
+            Upgrade => unreachable!(),
+        }
+        Ok(())
+    };
+
+    while !server_state.is_done() || !send_buf.lock().unwrap().is_empty() {
+        let send_buf = std::mem::take(&mut *send_buf.lock().unwrap());
+        if !send_buf.is_empty() {
+            eprintln!("Sending {send_buf:?}");
+            socket.write_all(&send_buf).await?;
+        } else if auth_ready.swap(false, Ordering::SeqCst) {
+            let built = match identity.clone().build() {
+                Ok(built) => built,
+                Err(e) => {
+                    server_state.drive(ConnectionDrive::Fail(PgError::InvalidAuthorizationSpecification(PgErrorInvalidAuthorizationSpecification::InvalidAuthorizationSpecification), "Missing database or user"), &mut update).unwrap();
+                    return Ok(());
+                }
+            };
+            resolved_identity = Some(built);
+            let auth = bound_config
+                .service()
+                .lookup_auth(
+                    resolved_identity.clone().unwrap(),
+                    AuthTarget::Stream(StreamLanguage::Postgres),
+                )
+                .await?;
+            server_state
+                .drive(
+                    ConnectionDrive::AuthInfo(auth.auth_type(), auth),
+                    &mut update,
+                )
+                .unwrap();
+        } else if params_ready.swap(false, Ordering::SeqCst) {
+            server_state
+                .drive(ConnectionDrive::Ready(1, 2), &mut update)
+                .unwrap();
+        } else {
+            let mut b = [0; 512];
+            let n = socket.read(&mut b).await?;
+            if n == 0 {
+                // EOF
+                return Ok(());
+            }
+            let res = server_state.drive(ConnectionDrive::RawMessage(&b[..n]), &mut update);
+            if res.is_err() {
+                // TODO?
+                error!("{res:?}");
+                return Ok(());
+            }
+        }
+    }
+
+    let socket = socket.upgrade(StreamPropertiesBuilder {
+        stream_params: Some(startup_params),
+        ..Default::default()
+    });
+    bound_config
+        .service()
+        .accept_stream(resolved_identity.unwrap(), StreamLanguage::Postgres, socket)
+        .await;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct BoundConfig<C: ListenerConfig, S: BabelfishService> {
+    config: Arc<C>,
+    service: Arc<S>,
+    ssl: SslContext,
+}
+
+impl<C: ListenerConfig, S: BabelfishService> BoundConfig<C, S> {
+    pub fn new(config: C, service: S) -> std::io::Result<Self> {
+        let config = Arc::new(config);
+        let ssl = create_ssl_for_listener_config(config.clone())?;
+        Ok(Self {
+            config,
+            service: service.into(),
+            ssl,
+        })
+    }
+}
+
+impl<C: ListenerConfig, S: BabelfishService> Clone for BoundConfig<C, S> {
+    fn clone(&self) -> Self {
+        Self {
+            config: Arc::clone(&self.config),
+            service: Arc::clone(&self.service),
+            ssl: self.ssl.clone(),
+        }
+    }
+}
+
+trait IsBoundConfig: Clone + Send + Sync + 'static {
+    type Config: ListenerConfig;
+    type Service: BabelfishService;
+
+    fn config(&self) -> &Arc<Self::Config>;
+    fn service(&self) -> &Arc<Self::Service>;
+    fn ssl(&self) -> std::io::Result<Ssl>;
+}
+
+impl<C: ListenerConfig, S: BabelfishService> IsBoundConfig for BoundConfig<C, S> {
+    type Config = C;
+    type Service = S;
+
+    #[inline(always)]
+    fn config(&self) -> &Arc<Self::Config> {
+        &self.config
+    }
+
+    #[inline(always)]
+    fn service(&self) -> &Arc<Self::Service> {
+        &self.service
+    }
+
+    fn ssl(&self) -> std::io::Result<Ssl> {
+        Ok(Ssl::new(&self.ssl)?)
+    }
+}
+
+pub struct BoundServer {
+    task: tokio::task::JoinHandle<std::io::Result<()>>,
+    addresses: tokio::sync::Mutex<tokio::sync::watch::Receiver<Option<Vec<ListenerAddress>>>>,
+}
+
+impl BoundServer {
+    pub fn bind(
+        config: impl ListenerConfig,
+        service: impl BabelfishService,
+    ) -> std::io::Result<Self> {
+        let config = BoundConfig::new(config, service)?;
+
+        trace!("Booting bound server with {config:#?}");
+
+        let (tx, rx) = tokio::sync::watch::channel(None);
+        let task = tokio::task::spawn(bind_task(tx, config.config().clone(), move |_, stm| {
+            let config = config.clone();
+            let identity = ConnectionIdentityBuilder::new();
+            if !config
+                .config
+                .is_supported(None, stm.transport_type(), stm.props())
+            {
+                return;
+            }
+            tokio::task::spawn(async move {
+                if let Err(e) =
+                    handle_connection_inner(StreamState::Raw, stm, identity, config).await
+                {
+                    error!("Connection error: {e:?}");
+                }
+            });
+        }));
+        Ok(Self {
+            task,
+            addresses: rx.into(),
+        })
+    }
+
+    pub async fn addresses(&self) -> Vec<ListenerAddress> {
+        let mut lock = self.addresses.lock().await;
+        let Ok(res) = lock.wait_for(|t| t.is_some()).await else {
+            return vec![];
+        };
+        res.clone().unwrap_or_default()
+    }
+
+    pub fn shutdown(self) -> impl Future<Output = ()> {
+        self.task.abort();
+        async {
+            _ = self.task.await;
+        }
+    }
+}
+
+fn create_ssl_for_listener_config(
+    config: Arc<impl ListenerConfig>,
+) -> Result<openssl::ssl::SslContext, std::io::Error> {
+    let mut ssl = openssl::ssl::SslContext::builder(SslMethod::tls_server())?;
+    {
+        ssl.set_servername_callback(move |ssl, alert| {
+            let Some(ex_data) = ssl.ex_data(get_ssl_ex_data_index()) else {
+                error!("Missing SSLExData");
+                *alert = SslAlert::ILLEGAL_PARAMETER;
+                return Err(SniError::ALERT_FATAL);
+            };
+            let hostname = ssl.servername(NameType::HOST_NAME);
+            eprintln!("SNI: {hostname:?}");
+            let (ssl_new, tenant) = config.ssl_config_sni(hostname).unwrap();
+            if let Some(tenant) = tenant {
+                ex_data.identity.set_tenant(tenant);
+            }
+            let config = config.clone();
+            let stream_props = ex_data.stream_props.clone();
+            let ssl_new = ssl_new.maybe_configure(move |ctx| {
+                ctx.set_alpn_select_callback(move |_, alpn| {
+                    trace!(
+                        "Server ALPN callback: {:?} ({:?})",
+                        std::str::from_utf8(alpn),
+                        alpn
+                    );
+                    let protocol = negotiate_alpn(config.as_ref(), alpn, &stream_props);
+                    trace!("Negotiated: {protocol:?}");
+                    if !alpn.is_empty() && protocol.is_none() {
+                        return Err(AlpnError::ALERT_FATAL);
+                    }
+                    protocol.map(|s| s.as_bytes()).ok_or(AlpnError::NOACK)
+                });
+            });
+            ssl.set_ssl_context(&ssl_new).unwrap();
+            Ok(())
+        });
+    };
+    let ssl = ssl.build();
+    Ok(ssl)
+}
+
+/// Bind on the stream of addresses provided by this listener.
+fn bind_task<C: ListenerConfig>(
+    tx: tokio::sync::watch::Sender<Option<Vec<ListenerAddress>>>,
+    config: Arc<C>,
+    callback: impl FnMut(Arc<C>, ListenerStream) + Send + Sync + 'static,
+) -> impl Future<Output = std::io::Result<()>> {
+    let callback = Arc::new(Mutex::new(callback));
+    async move {
+        let mut stm = pin!(config.listen_address());
+        let listeners = Mutex::new(HashMap::<
+            _,
+            (
+                ListenerAddress,
+                tokio::task::JoinHandle<std::io::Result<()>>,
+            ),
+        >::new());
+        defer!({
+            _ = tx.send(Some(vec![]));
+            for (_, (_, listener)) in listeners.lock().unwrap().drain() {
+                listener.abort()
+            }
+        });
+        while let Some(addresses) = stm.next().await.transpose()? {
+            info!("Requested to listen on {addresses:?}");
+            let new_listeners = HashSet::<_, RandomState>::from_iter(addresses);
+            listeners.lock().unwrap().retain(|k, (_, v)| {
+                // Remove any crashed tasks
+                if v.is_finished() {
+                    return false;
+                }
+                let res = new_listeners.contains(k);
+                if !res {
+                    v.abort();
+                }
+                res
+            });
+
+            for addr in new_listeners {
+                if listeners.lock().unwrap().contains_key(&addr) {
+                    continue;
+                }
+
+                let (resolved_addr, task) = match addr.clone() {
+                    ListenerAddress::Tcp(x) => {
+                        let config = config.clone();
+                        let listener = TcpListener::bind(x).await?;
+                        let local_addr = listener.local_addr()?.into();
+                        info!("Listening on {local_addr:?}");
+                        let callback = callback.clone();
+                        (
+                            local_addr,
+                            tokio::task::spawn(async move {
+                                loop {
+                                    let tcp = listener.accept().await?;
+                                    (callback.lock().unwrap())(
+                                        config.clone(),
+                                        ListenerStream::new_tcp(tcp.0),
+                                    );
+                                }
+                                #[allow(unreachable_code)]
+                                Ok::<_, std::io::Error>(())
+                            }),
+                        )
+                    }
+                    ListenerAddress::Unix(x) => {
+                        let config = config.clone();
+                        let listener = std::os::unix::net::UnixListener::bind_addr(&x)?;
+                        listener.set_nonblocking(true)?;
+                        let local_addr = ListenerAddress::from(Arc::new(listener.local_addr()?));
+                        info!("Listening on {local_addr:?}");
+                        let listener = UnixListener::from_std(listener)?;
+                        let callback = callback.clone();
+                        (
+                            local_addr.clone(),
+                            tokio::task::spawn(async move {
+                                loop {
+                                    let (stream, _) = listener.accept().await?;
+                                    let stream = stream.into_std()?;
+                                    let peer_addr =
+                                        stream.peer_addr().ok().map(|s| Arc::new(s).into());
+                                    let stream = UnixStream::from_std(stream)?;
+                                    let peer_cred = stream.peer_cred().ok();
+                                    (callback.lock().unwrap())(
+                                        config.clone(),
+                                        ListenerStream::new_unix(
+                                            stream,
+                                            Some(local_addr.clone()),
+                                            peer_addr,
+                                            peer_cred,
+                                        ),
+                                    );
+                                }
+                                #[allow(unreachable_code)]
+                                Ok::<_, std::io::Error>(())
+                            }),
+                        )
+                    }
+                };
+
+                listeners
+                    .lock()
+                    .unwrap()
+                    .insert(addr, (resolved_addr, task));
+                let addresses = listeners
+                    .lock()
+                    .unwrap()
+                    .values()
+                    .map(|(addr, _)| addr.clone())
+                    .collect();
+                _ = tx.send(Some(addresses));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gel_auth::CredentialData;
+    use hyper::Uri;
+    use hyper_util::rt::TokioIo;
+    use openssl::ssl::{Ssl, SslContext, SslMethod};
+    use rstest::rstest;
+    use tokio::net::TcpStream;
+
+    use crate::{
+        config::TestListenerConfig,
+        service::{AuthTarget, ConnectionIdentity, StreamLanguage},
+    };
+
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Captured from PostgreSQL 7.x
+    const LEGACY_POSTGRES: &[u8] = &[
+        0x00, 0x00, 0x01, 0x28, 0x00, 0x02, 0x00, 0x00, 0x6d, 0x61, 0x74, 0x74, 0x00, 0x00, 0x00,
+        0x00,
+    ];
+    /// Captured from OpenSSL 1.0.2k (using -ssl2)
+    const LEGACY_SSL2: &[u8] = &[
+        0x80, 0x25, 0x01, 0x00, 0x02, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x10, 0x05, 0x00, 0x80, 0x03,
+        0x00,
+    ];
+    /// Captured from a modern PostgreSQL client (version 16+)
+    const MODERN_POSTGRES: &[u8] = &[
+        0x00, 0x00, 0x00, 0x4c, 0x00, 0x03, 0x00, 0x00, 0x75, 0x73, 0x65, 0x72, 0x00, 0x6d, 0x61,
+        0x74,
+    ];
+    /// Captured from a modern EdgeDB client
+    const MODERN_EDGEDB: &[u8] = &[
+        0x56, 0x00, 0x00, 0x00, 0x4d, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x08,
+        0x64,
+    ];
+
+    #[derive(Clone, Debug, Default)]
+    struct TestService {
+        log: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl TestService {
+        fn log(&self, msg: String) {
+            eprintln!("{msg:?}");
+            self.log.lock().unwrap().push(msg);
+        }
+    }
+
+    enum TestMode {
+        Tcp,
+        Ssl,
+        SslAlpn(&'static str),
+    }
+
+    fn create_test_ssl_client(alpn: Option<&'static str>) -> openssl::ssl::SslContext {
+        let mut ctx = SslContext::builder(SslMethod::tls_client()).unwrap();
+        if let Some(alpn) = alpn {
+            let mut alpn = alpn.as_bytes().to_vec();
+            alpn.insert(0, alpn.len() as _);
+            ctx.set_alpn_protos(&alpn).unwrap();
+        }
+        ctx.build()
+    }
+
+    impl BabelfishService for TestService {
+        fn lookup_auth(
+            &self,
+            identity: ConnectionIdentity,
+            target: AuthTarget,
+        ) -> impl Future<Output = Result<CredentialData, std::io::Error>> {
+            self.log(format!("lookup_auth: {:?}", identity));
+            async { Ok(CredentialData::Trust) }
+        }
+
+        fn accept_stream(
+            &self,
+            identity: ConnectionIdentity,
+            language: StreamLanguage,
+            stream: ListenerStream,
+        ) -> impl Future<Output = Result<(), std::io::Error>> {
+            self.log(format!(
+                "accept_stream: {:?}, {:?}, {:?}",
+                identity, language, stream
+            ));
+            async { Ok(()) }
+        }
+
+        fn accept_http(
+            &self,
+            identity: ConnectionIdentity,
+            req: hyper::http::Request<hyper::body::Incoming>,
+        ) -> impl Future<Output = Result<hyper::http::Response<String>, std::io::Error>> {
+            self.log(format!("accept_http: {:?}, {:?}", identity, req));
+            async { Ok(Default::default()) }
+        }
+    }
+
+    /// Run a test server and connect to it.
+    fn run_test_service<F: Future<Output = Result<(), std::io::Error>> + Send + 'static>(
+        mode: TestMode,
+        f: impl Fn(ListenerStream) -> F + Send + 'static,
+    ) {
+        let svc = TestService::default();
+        let config = TestListenerConfig::new("localhost:0");
+
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async move {
+                let server = BoundServer::bind(config, svc).unwrap();
+                let addr = server
+                    .addresses()
+                    .await
+                    .first()
+                    .cloned()
+                    .unwrap()
+                    .tcp_addr()
+                    .unwrap();
+
+                let t2 = tokio::spawn(async move {
+                    let socket = ListenerStream::new_tcp(TcpStream::connect(addr).await.unwrap());
+                    let socket = match mode {
+                        TestMode::Tcp => socket,
+                        TestMode::Ssl => {
+                            let mut ssl = Ssl::new(&create_test_ssl_client(None)).unwrap();
+                            ssl.set_hostname("localhost").unwrap();
+                            socket.start_ssl(ssl).await.unwrap()
+                        }
+                        TestMode::SslAlpn(alpn) => {
+                            let mut ssl = Ssl::new(&create_test_ssl_client(Some(alpn))).unwrap();
+                            ssl.set_hostname("localhost").unwrap();
+                            socket.start_ssl(ssl).await.unwrap()
+                        }
+                    };
+                    f(socket).await.unwrap();
+                });
+
+                t2.await.unwrap();
+                server.shutdown().await;
+            });
+    }
+
+    /// Closes the connection with an error starting with "E" and ending in NUL.
+    #[rstest]
+    #[test_log::test]
+    fn test_legacy_postgres(#[values(TestMode::Tcp, TestMode::Ssl)] mode: TestMode) {
+        run_test_service(mode, |mut stm| async move {
+            stm.write_all(LEGACY_POSTGRES).await.unwrap();
+            let mut buf = vec![];
+            stm.read_to_end(&mut buf).await.unwrap();
+            assert_eq!(buf[0], b'E');
+            assert_eq!(buf[buf.len() - 1], 0);
+            Ok(())
+        });
+    }
+
+    /// Closes the connection with an SSLv2 error.
+    #[test_log::test]
+    fn test_legacy_ssl() {
+        run_test_service(TestMode::Tcp, |mut stm| async move {
+            stm.write_all(LEGACY_SSL2).await.unwrap();
+            let mut buf = vec![];
+            stm.read_to_end(&mut buf).await.unwrap();
+            assert_eq!(buf, vec![0x80, 3, 0, 0, 1]);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_raw_postgres() {
+        use pgrust::protocol::postgres::builder::{StartupMessage, StartupNameValue};
+        run_test_service(TestMode::Tcp, |mut stm| async move {
+            let msg = StartupMessage {
+                params: &[
+                    StartupNameValue {
+                        name: "database",
+                        value: "name",
+                    },
+                    StartupNameValue {
+                        name: "user",
+                        value: "me",
+                    },
+                ],
+            }
+            .to_vec();
+            stm.write_all(&msg).await.unwrap();
+            assert_eq!(stm.read_u8().await.unwrap(), b'R'); // AuthenticationOk
+            Ok(())
+        });
+    }
+
+    #[rstest]
+    #[test_log::test]
+    fn test_http_manual(
+        #[values(TestMode::Tcp, TestMode::Ssl, TestMode::SslAlpn("http/1.1"))] mode: TestMode,
+    ) {
+        run_test_service(mode, |mut stm| async move {
+            stm.write_all(b"GET /\r\n\r\n").await.unwrap();
+            let mut buf = vec![];
+            stm.read_to_end(&mut buf).await.unwrap();
+            let result = String::from_utf8(buf).unwrap();
+            assert_eq!(&result[..12], "HTTP/1.1 400");
+            Ok(())
+        });
+    }
+
+    #[rstest]
+    #[test_log::test]
+    fn test_http_1(
+        #[values(TestMode::Tcp, TestMode::Ssl, TestMode::SslAlpn("http/1.1"))] mode: TestMode,
+    ) {
+        run_test_service(mode, |stm| async move {
+            let http1 = hyper::client::conn::http1::Builder::new();
+            let (mut send, conn) = http1
+                .handshake::<_, String>(TokioIo::new(stm))
+                .await
+                .unwrap();
+            tokio::task::spawn(conn);
+            let req = hyper::Request::new("x".to_string());
+            let resp = send.send_request(req).await.unwrap();
+            eprintln!("{resp:?}");
+            Ok(())
+        });
+    }
+
+    #[rstest]
+    #[test_log::test]
+    fn test_http_2(
+        #[values(TestMode::Tcp, TestMode::Ssl, TestMode::SslAlpn("h2"))] mode: TestMode,
+    ) {
+        run_test_service(mode, |stm| {
+            async move {
+                let http2 =
+                    hyper::client::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new());
+                let (mut send, conn) = http2
+                    .handshake::<_, String>(TokioIo::new(stm))
+                    .await
+                    .unwrap();
+                tokio::task::spawn(conn);
+                let req = hyper::Request::new("x".to_string());
+                let resp = send.send_request(req).await.unwrap();
+                eprintln!("{resp:?}");
+
+                // assert_eq!(stm.read_u8().await.unwrap(), b'S');
+                Ok(())
+            }
+        });
+    }
+
+    #[rstest]
+    #[test_log::test]
+    fn test_tunneled_edgedb(
+        #[values(TestMode::Tcp, TestMode::Ssl, TestMode::SslAlpn("h2"))] mode: TestMode,
+    ) {
+        run_test_service(mode, |stm| {
+            async move {
+                let http2 =
+                    hyper::client::conn::http2::Builder::new(hyper_util::rt::TokioExecutor::new());
+                let (mut send, conn) = http2.handshake::<_, _>(TokioIo::new(stm)).await.unwrap();
+                tokio::task::spawn(conn);
+                let mut body = vec![];
+                body.extend_from_slice(b"O\x00\x00\x00\xef\x00\x00\xff\xff\xff\xff\xff\xff\xff\xd9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00bo\x00\x00\x00\x93");
+                body.extend_from_slice(b"\n      select {\n        instanceName := sys::get_instance_name(),\n        databases := sys::Database.name,\n        roles := sys::Role.name,\n      }");
+                body.extend_from_slice(b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00");
+                body.extend_from_slice(b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00S\x00\x00\x00\x04");
+                let mut req =
+                    hyper::Request::new(http_body_util::Full::new(hyper::body::Bytes::from(body)));
+                *req.uri_mut() = Uri::from_static("/db/./mydb");
+                let resp = send.send_request(req).await.unwrap();
+                eprintln!("{resp:?}");
+
+                // assert_eq!(stm.read_u8().await.unwrap(), b'S');
+                Ok(())
+            }
+        });
+    }
+}

--- a/gel-frontend/src/python.rs
+++ b/gel-frontend/src/python.rs
@@ -1,0 +1,16 @@
+#[cfg(test)]
+mod tests {
+    use pyo3::{types::PyAnyMethods, Python};
+
+    use super::*;
+
+    #[test]
+    fn test_python_extension() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let sys = py.import("sys").unwrap();
+            let version = sys.getattr("version").unwrap();
+            println!("Python version: {}", version);
+        });
+    }
+}

--- a/gel-frontend/src/service.rs
+++ b/gel-frontend/src/service.rs
@@ -1,0 +1,147 @@
+use gel_auth::CredentialData;
+
+use crate::stream::ListenerStream;
+use std::{
+    future::Future,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug)]
+pub enum StreamLanguage {
+    Postgres,
+    EdgeDB,
+    EdgeDBJSON,
+    EdgeDBNotebook,
+}
+
+pub enum AuthTarget {
+    Stream(StreamLanguage),
+    HTTP(String),
+}
+
+#[derive(Clone, Debug)]
+pub enum BranchDB {
+    /// Branch only.
+    Branch(String),
+    /// Database name (legacy).
+    DB(String),
+    /// Postgres database name.
+    PGDB(String),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum IdentityError {
+    #[error("No user specified")]
+    NoUser,
+    #[error("No database specified")]
+    NoDb,
+}
+
+#[derive(Clone, Debug)]
+pub struct ConnectionIdentityBuilder {
+    tenant: Arc<Mutex<Option<String>>>,
+    db: Arc<Mutex<Option<BranchDB>>>,
+    user: Arc<Mutex<Option<String>>>,
+}
+
+impl Default for ConnectionIdentityBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConnectionIdentityBuilder {
+    pub fn new() -> Self {
+        Self {
+            tenant: Arc::new(Mutex::new(None)),
+            db: Arc::new(Mutex::new(None)),
+            user: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn set_tenant(&self, tenant: String) -> &Self {
+        *self.tenant.lock().unwrap() = Some(tenant);
+        self
+    }
+
+    pub fn set_database(&self, database: String) -> &Self {
+        if !database.is_empty() {
+            // Only set if currently non-empty
+            let mut db = self.db.lock().unwrap();
+            if db.is_none() {
+                *db = Some(BranchDB::DB(database));
+            }
+        }
+        self
+    }
+
+    pub fn set_branch(&self, branch: String) -> &Self {
+        if !branch.is_empty() {
+            *self.db.lock().unwrap() = Some(BranchDB::Branch(branch));
+        }
+        self
+    }
+
+    pub fn set_pg_database(&self, database: String) -> &Self {
+        if !database.is_empty() {
+            *self.db.lock().unwrap() = Some(BranchDB::PGDB(database));
+        }
+        self
+    }
+
+    pub fn set_user(&self, user: String) -> &Self {
+        *self.user.lock().unwrap() = Some(user);
+        self
+    }
+
+    /// Create a new, disconnected builder.
+    pub fn new_builder(&self) -> Self {
+        Self {
+            tenant: Arc::new(Mutex::new(self.tenant.lock().unwrap().clone())),
+            db: Arc::new(Mutex::new(self.db.lock().unwrap().clone())),
+            user: Arc::new(Mutex::new(self.user.lock().unwrap().clone())),
+        }
+    }
+
+    fn unwrap_or_clone<T: Clone>(arc: Arc<Mutex<T>>) -> T {
+        match Arc::try_unwrap(arc) {
+            Ok(mutex) => mutex.into_inner().unwrap(),
+            Err(arc) => arc.lock().unwrap().clone(),
+        }
+    }
+
+    pub fn build(self) -> Result<ConnectionIdentity, IdentityError> {
+        let tenant = Self::unwrap_or_clone(self.tenant);
+        let db = Self::unwrap_or_clone(self.db).ok_or(IdentityError::NoDb)?;
+        let user = Self::unwrap_or_clone(self.user).ok_or(IdentityError::NoUser)?;
+
+        Ok(ConnectionIdentity { tenant, db, user })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ConnectionIdentity {
+    pub tenant: Option<String>,
+    pub db: BranchDB,
+    pub user: String,
+}
+
+/// Handles incoming connections from the listener which might be streams or HTTP.
+pub trait BabelfishService: std::fmt::Debug + Send + Sync + 'static {
+    fn lookup_auth(
+        &self,
+        identity: ConnectionIdentity,
+        target: AuthTarget,
+    ) -> impl Future<Output = Result<CredentialData, std::io::Error>> + Send + Sync;
+    fn accept_stream(
+        &self,
+        identity: ConnectionIdentity,
+        language: StreamLanguage,
+        stream: ListenerStream,
+    ) -> impl Future<Output = Result<(), std::io::Error>> + Send;
+    fn accept_http(
+        &self,
+        identity: ConnectionIdentity,
+        req: hyper::http::Request<hyper::body::Incoming>,
+    ) -> impl Future<Output = Result<hyper::http::Response<String>, std::io::Error>>;
+}

--- a/gel-frontend/src/stream.rs
+++ b/gel-frontend/src/stream.rs
@@ -1,0 +1,498 @@
+use crate::{
+    config::ListenerAddress,
+    hyper::{HyperStream, HyperUpgradedStream},
+    stream_type::{known_protocol, StreamType},
+};
+use core::str;
+use hyper::{HeaderMap, Version};
+use openssl::{ssl::NameType, x509::X509};
+use std::{
+    collections::HashMap,
+    io::{ErrorKind, IoSlice},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::{unix::UCred, TcpStream, UnixStream},
+};
+use tracing::error;
+
+macro_rules! stream_properties {
+    (
+        $(#[doc=$doc:literal] pub $name:ident: $type:ty),+ $(,)?
+    ) => {
+        #[derive(Clone, Default, Debug)]
+        pub struct StreamPropertiesBuilder {
+            $(
+                #[doc=$doc]
+                pub $name: $type,
+            )+
+        }
+
+        pub struct StreamProperties {
+            /// A parent transport, if one exists
+            pub parent: Option<Arc<StreamProperties>>,
+            /// The underlying transport type
+            pub transport: TransportType,
+            $(
+                #[doc=$doc]
+                pub $name: $type,
+            )+
+        }
+
+        impl StreamProperties {
+            pub fn new(transport: TransportType) -> Self {
+                StreamProperties {
+                    parent: None,
+                    transport,
+                    $($name: None),+
+                }
+            }
+
+            pub fn upgrade(self: Arc<Self>, props: StreamPropertiesBuilder) -> Arc<Self> {
+                let transport = self.transport;
+                Arc::new(StreamProperties {
+                    parent: Some(self),
+                    transport,
+                    $($name: props.$name),+
+                })
+            }
+
+            $(
+                pub fn $name(&self) -> &$type {
+                    &self.$name
+                }
+            )+
+        }
+
+        impl std::fmt::Debug for StreamProperties {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let mut debug_struct = f.debug_struct("StreamProperties");
+
+                debug_struct.field("transport", &self.transport);
+                $(
+                    if let Some($name) = &self.$name {
+                        debug_struct.field(stringify!($name), $name);
+                    }
+                )+
+                if let Some(parent) = &self.parent {
+                    debug_struct.field("parent", parent);
+                }
+
+                debug_struct.finish()
+            }
+        }
+    };
+}
+
+stream_properties! {
+    /// The language or protocol of the stream
+    pub language: Option<StreamType>,
+    /// The local address of the connection
+    pub local_addr: Option<ListenerAddress>,
+    /// The peer address of the connection
+    pub peer_addr: Option<ListenerAddress>,
+    /// The peer credentials (for Unix domain sockets)
+    pub peer_creds: Option<UCred>,
+    /// The HTTP version used (for HTTP connections)
+    pub http_version: Option<Version>,
+    /// The HTTP request headers (for HTTP connections)
+    pub request_headers: Option<HeaderMap>,
+    /// The stream parameters (for PG/EDB connections)
+    pub stream_params: Option<HashMap<String, String>>,
+    /// The peer's SSL certificate (for SSL connections)
+    pub peer_certificate: Option<X509>,
+    /// The SSL/TLS version.
+    pub ssl_version: Option<openssl::ssl::SslVersion>,
+    /// The SSL/TLS version.
+    pub ssl_cipher_name: Option<&'static str>,
+    /// The Server Name Indication (SNI) provided by the client (for SSL connections)
+    pub server_name_indication: Option<String>,
+    /// The negotiated protocol (e.g., for ALPN in SSL connections, protocol for WebSocket)
+    pub protocol: Option<&'static str>,
+}
+
+pub struct RewindStream<S> {
+    buffer: Vec<u8>,
+    inner: S,
+}
+
+impl<S> RewindStream<S> {
+    pub fn new(inner: S) -> Self {
+        RewindStream {
+            buffer: Vec::new(),
+            inner,
+        }
+    }
+
+    pub fn rewind(&mut self, data: &[u8]) {
+        self.buffer.extend_from_slice(data);
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for RewindStream<S> {
+    #[inline(always)]
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if !self.buffer.is_empty() {
+            let to_read = std::cmp::min(buf.remaining(), self.buffer.len());
+            let data = self.buffer.drain(..to_read).collect::<Vec<_>>();
+            buf.put_slice(&data);
+            Poll::Ready(Ok(()))
+        } else {
+            Pin::new(&mut self.inner).poll_read(cx, buf)
+        }
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for RewindStream<S> {
+    #[inline(always)]
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    #[inline(always)]
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    #[inline(always)]
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+
+    #[inline(always)]
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    #[inline(always)]
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TransportType {
+    Tcp,
+    Unix,
+    Ssl,
+    Http,
+    WebSocket,
+}
+
+/// As we may be dealing with multiple types of streams, we have one top-level stream type that
+/// dispatches to the appropriate underlying stream type.
+pub struct ListenerStream {
+    stream_properties: Arc<StreamProperties>,
+    inner: ListenerStreamInner,
+}
+
+enum ListenerStreamInner {
+    /// Raw TCP stream.
+    Tcp(RewindStream<TcpStream>),
+    /// Raw Unix stream.
+    #[cfg(unix)]
+    Unix(RewindStream<UnixStream>),
+    /// Stream tunneled through HTTP request/response.
+    Http(HyperStream),
+    /// Upgraded stream (WebSocket, CONNECT, etc).
+    WebSocket(HyperUpgradedStream),
+    /// SSL stream.
+    Ssl(RewindStream<tokio_openssl::SslStream<RewindStream<TcpStream>>>),
+}
+
+impl ListenerStream {
+    pub fn new_tcp(stream: TcpStream) -> Self {
+        let stream_properties = StreamProperties {
+            peer_addr: stream.peer_addr().ok().map(|s| s.into()),
+            local_addr: stream.peer_addr().ok().map(|s| s.into()),
+            ..StreamProperties::new(TransportType::Tcp)
+        }
+        .into();
+        ListenerStream {
+            stream_properties,
+            inner: ListenerStreamInner::Tcp(RewindStream::new(stream)),
+        }
+    }
+
+    #[cfg(unix)]
+    pub fn new_unix(
+        stream: UnixStream,
+        local_addr: Option<ListenerAddress>,
+        peer_addr: Option<ListenerAddress>,
+        peer_creds: Option<UCred>,
+    ) -> Self {
+        let stream_properties = StreamProperties {
+            peer_addr,
+            local_addr,
+            peer_creds,
+            ..StreamProperties::new(TransportType::Unix)
+        }
+        .into();
+        ListenerStream {
+            stream_properties,
+            inner: ListenerStreamInner::Unix(RewindStream::new(stream)),
+        }
+    }
+
+    pub fn new_websocket(stream_props: StreamProperties, stream: HyperUpgradedStream) -> Self {
+        ListenerStream {
+            stream_properties: stream_props.into(),
+            inner: ListenerStreamInner::WebSocket(stream),
+        }
+    }
+
+    pub async fn peek(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+        match &mut self.inner {
+            ListenerStreamInner::Tcp(stream) => {
+                if !stream.buffer.is_empty() {
+                    todo!()
+                }
+                stream.inner.peek(buf).await
+            }
+            ListenerStreamInner::Ssl(stream) => {
+                if !stream.buffer.is_empty() {
+                    todo!()
+                }
+                Pin::new(&mut stream.inner)
+                    .peek(buf)
+                    .await
+                    .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e))
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    /// If this channel allows for non-blocking write attempts, give it a shot to avoid polling.
+    pub fn try_write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
+        match &mut self.inner {
+            ListenerStreamInner::Tcp(stream) => stream.inner.try_write(buf),
+            ListenerStreamInner::Unix(stream) => stream.inner.try_write(buf),
+            _ => Ok(0),
+        }
+    }
+
+    pub fn rewind(&mut self, buffer: &[u8]) {
+        match &mut self.inner {
+            ListenerStreamInner::Tcp(stream) => stream.rewind(buffer),
+            ListenerStreamInner::Ssl(stream) => stream.rewind(buffer),
+            _ => unimplemented!(),
+        }
+    }
+
+    pub async fn start_ssl(self, ssl: openssl::ssl::Ssl) -> Result<Self, std::io::Error> {
+        match self.inner {
+            ListenerStreamInner::Tcp(stream) => {
+                let parent_stream_properties = self.stream_properties.clone();
+
+                let mut ssl_stream = tokio_openssl::SslStream::new(ssl, stream)?;
+                let is_server = ssl_stream.ssl().is_server();
+                let ssl = Pin::new(&mut ssl_stream);
+                if is_server {
+                    ssl.accept().await
+                } else {
+                    ssl.connect().await
+                }
+                .map_err(|e| {
+                    error!("{:?} {:?}", e.io_error(), e.ssl_error());
+                    std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+                })?;
+
+                let ssl = ssl_stream.ssl();
+                let stream_properties = StreamProperties {
+                    parent: Some(parent_stream_properties),
+                    protocol: ssl.selected_alpn_protocol().and_then(known_protocol),
+                    peer_certificate: ssl.peer_certificate(),
+                    ssl_version: ssl.version2(),
+                    ssl_cipher_name: ssl.current_cipher().map(|c| c.name()),
+                    server_name_indication: ssl
+                        .servername(NameType::HOST_NAME)
+                        .map(|s| s.to_string()),
+                    ..StreamProperties::new(TransportType::Ssl)
+                }
+                .into();
+
+                Ok(ListenerStream {
+                    stream_properties,
+                    inner: ListenerStreamInner::Ssl(RewindStream::new(ssl_stream)),
+                })
+            }
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "SSL connection cannot be establed on this transport",
+            )),
+        }
+    }
+
+    /// If the underlying stream is SSL or a WebSocket, retrieves the negotiated
+    /// protocol.
+    pub fn selected_protocol(&self) -> Option<&'static str> {
+        self.stream_properties.protocol
+    }
+
+    /// Returns the transport type of the underlying stream.
+    pub fn transport_type(&self) -> TransportType {
+        match self.inner {
+            ListenerStreamInner::Tcp(..) => TransportType::Tcp,
+            ListenerStreamInner::Ssl(..) => TransportType::Ssl,
+            ListenerStreamInner::Http(..) => TransportType::Http,
+            ListenerStreamInner::WebSocket(..) => TransportType::WebSocket,
+            ListenerStreamInner::Unix(..) => TransportType::Unix,
+        }
+    }
+
+    /// Returns the peer address of the underlying stream.
+    #[inline(always)]
+    pub fn props(&self) -> &StreamProperties {
+        &self.stream_properties
+    }
+
+    /// Returns the peer address of the underlying stream.
+    #[inline(always)]
+    pub fn props_clone(&self) -> Arc<StreamProperties> {
+        self.stream_properties.clone()
+    }
+
+    /// Returns the local address of the underlying stream.
+    pub fn local_addr(&self) -> Option<&ListenerAddress> {
+        self.stream_properties.local_addr.as_ref()
+    }
+
+    /// Returns the peer address of the underlying stream.
+    pub fn peer_addr(&self) -> Option<&ListenerAddress> {
+        self.stream_properties.local_addr.as_ref()
+    }
+
+    pub fn upgrade(self, props: StreamPropertiesBuilder) -> Self {
+        Self {
+            inner: self.inner,
+            stream_properties: self.stream_properties.upgrade(props),
+        }
+    }
+}
+
+macro_rules! with_mut_stream {
+    ($self:expr, $stream:ident, $action:expr) => {
+        match &mut $self.inner {
+            ListenerStreamInner::Tcp($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+            ListenerStreamInner::Ssl($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+            ListenerStreamInner::Http($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+            ListenerStreamInner::WebSocket($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+            ListenerStreamInner::Unix($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+        }
+    };
+}
+
+macro_rules! with_ref_stream {
+    ($self:expr, $stream:ident, $action:expr) => {
+        match &$self.inner {
+            ListenerStreamInner::Tcp($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+            ListenerStreamInner::Ssl($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+            ListenerStreamInner::Http($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+            ListenerStreamInner::WebSocket($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+            ListenerStreamInner::Unix($stream) => {
+                let $stream = Pin::new($stream);
+                $action
+            }
+        }
+    };
+}
+
+impl std::fmt::Debug for ListenerStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}({:?})", self.transport_type(), self.props())
+    }
+}
+
+impl AsyncRead for ListenerStream {
+    #[inline]
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        with_mut_stream!(self.get_mut(), stream, stream.poll_read(cx, buf))
+    }
+}
+
+impl AsyncWrite for ListenerStream {
+    #[inline]
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        with_mut_stream!(self.get_mut(), stream, stream.poll_write(cx, buf))
+    }
+
+    #[inline]
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        with_mut_stream!(self.get_mut(), stream, stream.poll_flush(cx))
+    }
+
+    #[inline]
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        with_mut_stream!(self.get_mut(), stream, stream.poll_shutdown(cx))
+    }
+
+    #[inline]
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        with_mut_stream!(self.get_mut(), stream, stream.poll_write_vectored(cx, bufs))
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        with_ref_stream!(self, stream, stream.as_ref().is_write_vectored())
+    }
+}

--- a/gel-frontend/src/stream_type.rs
+++ b/gel-frontend/src/stream_type.rs
@@ -1,0 +1,383 @@
+use tokio::io::AsyncReadExt;
+use tracing::{error, trace};
+
+use crate::{
+    config::ListenerConfig,
+    stream::{ListenerStream, StreamProperties, TransportType},
+};
+
+const PREFACE_SIZE: usize = 8;
+const MIN_PREFACE_SIZE: usize = 5;
+
+const HTTP_2: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+const HTTP_2_PREFACE: [u8; PREFACE_SIZE] = [
+    HTTP_2[0], HTTP_2[1], HTTP_2[2], HTTP_2[3], HTTP_2[4], HTTP_2[5], HTTP_2[6], HTTP_2[7],
+];
+
+#[derive(Clone, Copy, Debug)]
+pub enum PostgresInitialMessage {
+    StartupMessage,
+    SSLRequest,
+    GSSENCRequest,
+    Cancellation,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum StreamState {
+    /// A stream that is in the raw state.
+    Raw,
+    /// A stream that began in SSL.
+    Ssl,
+    /// A stream that has gone through the Postgres SSL upgrade handshake (whether successful or not).
+    PgSslUpgrade,
+    /// A stream encapsulated within another stream (ie: WebSocket/HTTP)
+    Encapsulated,
+}
+
+/// Represents the different types of streams that can be identified.
+#[derive(Clone, Copy, Debug)]
+pub enum StreamType {
+    /// PostgreSQL initial messages.
+    PostgresInitial(PostgresInitialMessage),
+    /// SSL/TLS connection.
+    SSLTLS,
+    /// EdgeDB binary protocol.
+    EdgeDBBinary,
+    /// HTTP/2 protocol.
+    HTTP2,
+    /// HTTP/1.x protocols.
+    HTTP1x,
+}
+
+impl StreamType {
+    pub fn go_away_message(&self) -> &'static [u8] {
+        match self {
+            StreamType::PostgresInitial(_) => {
+                b"E\0\0\0\x3dSFATAL\0VFATAL\0C0A000\0MPostgreSQL protocol not supported\0\0"
+            }
+            StreamType::SSLTLS => b"\x15\x03\x00\x00\x02\x02\x46", // TLS Alert: Protocol Version (0x46) - Handshake Failure
+            StreamType::EdgeDBBinary => {
+                // FATAL error response for EdgeDB binary protocol
+                &[
+                    0x45, // 'E'
+                    0x00, 0x00, 0x00, 13,   // Message length
+                    0xC8, // Severity: FATAL
+                    0x0A, 0x00, 0x00, 0x00, // Error code: Protocol error
+                    0x45, 0x00, // Null-terminated message
+                    0x00, 0x00, // Number of attributes (0)
+                ]
+            }
+            StreamType::HTTP2 => &[
+                // SETTINGS frame
+                0x00, 0x00, 0x00, // Length (0 for empty SETTINGS)
+                0x04, // Type (SETTINGS)
+                0x00, // Flags
+                0x00, 0x00, 0x00, 0x00, // Stream Identifier
+                // GOAWAY frame
+                0x00, 0x00, 0x08, // Length
+                0x07, // Type (GOAWAY)
+                0x00, // Flags
+                0x00, 0x00, 0x00, 0x00, // Stream Identifier
+                0x00, 0x00, 0x00, 0x00, // Last-Stream-ID
+                0x00, 0x00, 0x00, 0x0d, // Error Code (PROTOCOL_ERROR)
+            ],
+            StreamType::HTTP1x => {
+                b"HTTP/1.1 505 HTTP Version Not Supported\r\nContent-Length: 0\r\n\r\n"
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum UnknownStreamType {
+    Unknown,
+    PostgresInitial,
+    SSLLegacy,
+    PostgresWireLegacy,
+}
+
+impl UnknownStreamType {
+    pub fn go_away_message(&self) -> &'static [u8] {
+        match self {
+            UnknownStreamType::Unknown => b"Invalid startup message",
+            UnknownStreamType::PostgresInitial => {
+                b"E\0\0\0\x89SFATAL\0VFATAL\0C0A000\0Munsupported startup message\0\0"
+            }
+            // This response results in an OpenSSL error of "no cipher" which is
+            // a decent way to respond.
+            // "SSL routines:GET_SERVER_HELLO:peer error no cipher:s2_pkt.c:667:"
+            UnknownStreamType::SSLLegacy => b"\x80\x03\0\0\x01",
+            // This is sufficient to make any PostgreSQL version go away
+            UnknownStreamType::PostgresWireLegacy => b"EInvalid protocol\0",
+        }
+    }
+}
+
+const fn is_likely_http1(a1: u8, a2: u8, a3: u8, a4: u8) -> bool {
+    a1.is_ascii_uppercase()
+        && a2.is_ascii_uppercase()
+        && a3.is_ascii_uppercase()
+        && (a4.is_ascii_uppercase() || a4.is_ascii_whitespace())
+}
+
+const fn identify_connection(
+    state: StreamState,
+    buf: &[u8; PREFACE_SIZE],
+) -> Result<StreamType, UnknownStreamType> {
+    match (state, buf) {
+        // Legacy Postgres wire protocol (Network order length = 296, major version = 2)
+        // Example connection from PostgreSQL 7.x:
+        // 00000000  00 00 01 28 00 02 00 00  6d 61 74 74 00 00 00 00  |...(....matt....|
+        (_, [0, 0, 0x01, 0x28, 0, 2, _, _]) => Err(UnknownStreamType::PostgresWireLegacy),
+
+        // SSL 2: Record type 0x01 (ClientHello)
+        // Example connection from openssl 1.0.2k with `-ssl2`:
+        // 00000000  80 25 01 00 02 00 0c 00  00 00 10 05 00 80 03 00  |.%..............|
+        // 00000010  80 01 00 80 07 00 c0 37  9b dc 4b 94 2c ba 14 57  |.......7..K.,..W|
+        (StreamState::Raw, [b0, b1, 0x01, ..]) if (*b0 & 0x80 == 0x80) && (((*b0 as u16 & 0x7f) << 8 | *b1 as u16) > 9) => Err(UnknownStreamType::SSLLegacy),
+
+        // Postgres wire protocol: Startup message with length 13 or more, protocol = 0x30000
+        (_, [0, 0, len_hi, len_lo, 0, 3, 0, 0]) if u32::from_be_bytes([0, 0, *len_hi, *len_lo]) >= 13 => Ok(StreamType::PostgresInitial(PostgresInitialMessage::StartupMessage)),
+
+        // Postgres SSLRequest startup message (length 8, code 0x4d2162f)
+        (StreamState::Raw, [0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x2f]) => Ok(StreamType::PostgresInitial(PostgresInitialMessage::SSLRequest)),
+
+        // Postgres GSSENCRequest startup message (length 8, code 0x4d21630)
+        (_, [0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x30]) => Ok(StreamType::PostgresInitial(PostgresInitialMessage::GSSENCRequest)),
+
+        // Other Postgres startup message (length 8 or 16, code 0x4d2....)
+        (_, [0, 0, 0, 8 | 16, 0x04, 0xd2, _, _]) => Ok(StreamType::PostgresInitial(PostgresInitialMessage::Cancellation)),
+
+        // Other Postgres startup message (code 0x4d216??)
+        (_, [0, 0, _, _, 0x04, 0xd2, 0x16, _]) => Err(UnknownStreamType::PostgresInitial),
+
+        // SSL 3.0 or TLS 1.0+: Record type 0x16 (Handshake), Version 3.0 or higher
+        (StreamState::Raw, [0x16, 0x03, _, _, _, 0x01, ..]) => Ok(StreamType::SSLTLS),
+
+        // EdgeDB binary protocol (ClientHandshake): 'V' followed by 7 bytes (including length)
+        (StreamState::Raw | StreamState::Ssl | StreamState::Encapsulated, [b'V', 0, 0, 0, _, _, _, _]) => Ok(StreamType::EdgeDBBinary),
+
+        // HTTP/2: Connection Preface
+        (StreamState::Raw | StreamState::Ssl, &HTTP_2_PREFACE) => Ok(StreamType::HTTP2),
+
+        // HTTP/1.x: Various HTTP methods
+
+        // GET /<*>
+        (StreamState::Raw | StreamState::Ssl, [b'G', b'E', b'T', b' ', b'/', ..] |
+        // POST /<*>
+        [b'P', b'O', b'S', b'T', b' ', b'/', ..] |
+        // PUT /<*>
+        [b'P', b'U', b'T', b' ', b'/', ..] |
+        // DELETE /<*>
+        [b'D', b'E', b'L', b'E', b'T', b'E', b' ', ..] |
+        // HEAD /<*>
+        [b'H', b'E', b'A', b'D', b' ', b'/', ..] |
+        // OPTIONS /<*> or OPTIONS *
+        [b'O', b'P', b'T', b'I', b'O', b'N', b'S', ..] |
+        // PATCH /<*>
+        [b'P', b'A', b'T', b'C', b'H', b' ', b'/', ..] |
+        // TRACE /<*>
+        [b'T', b'R', b'A', b'C', b'E', b' ', b'/', ..] |
+        // CONNECT <*>
+        [b'C', b'O', b'N', b'N', b'E', b'C', b'T', b' ']) => Ok(StreamType::HTTP1x),
+        // Other less common HTTP methods, assume HTTP/1.x if the first
+        // four bytes look like an HTTP method
+        (StreamState::Raw | StreamState::Ssl, [a1, a2, a3, a4, ..]) if is_likely_http1(*a1, *a2, *a3, *a4) => Ok(StreamType::HTTP1x),
+
+        // Unknown protocol
+        _ => Err(UnknownStreamType::Unknown),
+    }
+}
+
+const STR_EDGEDB_BINARY: &str = "edgedb-binary";
+const STR_POSTGRESQL: &str = "postgresql";
+const STR_HTTP2: &str = "h2";
+const STR_HTTP1_1: &str = "http/1.1";
+const ALPN_EDGEDB_BINARY: &[u8] = STR_EDGEDB_BINARY.as_bytes();
+const ALPN_POSTGRESQL: &[u8] = STR_POSTGRESQL.as_bytes();
+const ALPN_HTTP2: &[u8] = STR_HTTP2.as_bytes();
+const ALPN_HTTP1_1: &[u8] = STR_HTTP1_1.as_bytes();
+
+pub fn negotiate_alpn(
+    config: &impl ListenerConfig,
+    alpn: &[u8],
+    stream_props: &StreamProperties,
+) -> Option<&'static str> {
+    let mut i = 0;
+    let mut edgedb_binary = false;
+    let mut postgresql = false;
+    let mut h2 = false;
+    let mut http1_1 = false;
+
+    while i < alpn.len() {
+        let len = alpn[i] as usize;
+        if i + 1 + len > alpn.len() {
+            break;
+        }
+        let protocol = &alpn[i + 1..i + 1 + len];
+        match protocol {
+            ALPN_EDGEDB_BINARY => {
+                edgedb_binary = true;
+            }
+            ALPN_POSTGRESQL => {
+                postgresql = true;
+            }
+            ALPN_HTTP2 => {
+                h2 = true;
+            }
+            ALPN_HTTP1_1 => {
+                http1_1 = true;
+            }
+            _ => {}
+        }
+        i += 1 + len;
+    }
+
+    if edgedb_binary
+        && config.is_supported(
+            Some(StreamType::EdgeDBBinary),
+            TransportType::Ssl,
+            stream_props,
+        )
+    {
+        Some(STR_EDGEDB_BINARY)
+    } else if postgresql
+        && config.is_supported(
+            Some(StreamType::PostgresInitial(
+                PostgresInitialMessage::StartupMessage,
+            )),
+            TransportType::Ssl,
+            stream_props,
+        )
+    {
+        Some(STR_POSTGRESQL)
+    } else if h2 && config.is_supported(Some(StreamType::HTTP2), TransportType::Ssl, stream_props) {
+        Some(STR_HTTP2)
+    } else if http1_1
+        && config.is_supported(Some(StreamType::HTTP1x), TransportType::Ssl, stream_props)
+    {
+        Some(STR_HTTP1_1)
+    } else {
+        error!("No supported ALPN protocol found");
+        None
+    }
+}
+
+pub fn negotiate_ws_protocol(
+    config: &impl ListenerConfig,
+    protocols: &str,
+    stream_props: &StreamProperties,
+) -> Option<&'static str> {
+    let mut edgedb_binary = false;
+    let mut postgresql = false;
+
+    for protocol in protocols.split(',') {
+        match protocol.trim() {
+            STR_EDGEDB_BINARY => {
+                edgedb_binary = true;
+            }
+            STR_POSTGRESQL => {
+                postgresql = true;
+            }
+            _ => {}
+        }
+    }
+
+    if edgedb_binary
+        && config.is_supported(
+            Some(StreamType::EdgeDBBinary),
+            TransportType::WebSocket,
+            stream_props,
+        )
+    {
+        Some(STR_EDGEDB_BINARY)
+    } else if postgresql
+        && config.is_supported(
+            Some(StreamType::PostgresInitial(
+                PostgresInitialMessage::StartupMessage,
+            )),
+            TransportType::WebSocket,
+            stream_props,
+        )
+    {
+        Some(STR_POSTGRESQL)
+    } else {
+        error!("No supported WebSocket protocol found");
+        None
+    }
+}
+
+/// Identifies the ALPN protocol and returns the corresponding StreamType
+fn identify_alpn(alpn: &[u8]) -> Result<StreamType, UnknownStreamType> {
+    match alpn {
+        ALPN_EDGEDB_BINARY => Ok(StreamType::EdgeDBBinary),
+        ALPN_POSTGRESQL => Ok(StreamType::PostgresInitial(
+            PostgresInitialMessage::StartupMessage,
+        )),
+        ALPN_HTTP2 => Ok(StreamType::HTTP2),
+        ALPN_HTTP1_1 => Ok(StreamType::HTTP1x),
+        _ => Err(UnknownStreamType::Unknown),
+    }
+}
+
+/// Maps a byte slice to the corresponding ALPN protocol string.
+pub fn known_protocol(alpn: &[u8]) -> Option<&'static str> {
+    match alpn {
+        ALPN_EDGEDB_BINARY => Some(STR_EDGEDB_BINARY),
+        ALPN_POSTGRESQL => Some(STR_POSTGRESQL),
+        ALPN_HTTP2 => Some(STR_HTTP2),
+        ALPN_HTTP1_1 => Some(STR_HTTP1_1),
+        _ => None,
+    }
+}
+
+/// Identifies the stream type based on the initial bytes read from the socket or ALPN protocol.
+/// This function correctly rewinds the stream if needed.
+pub async fn identify_stream(
+    state: StreamState,
+    socket: &mut ListenerStream,
+) -> Result<StreamType, UnknownStreamType> {
+    // If we have a negotiated ALPN/websocket type, we don't need to sniff the stream
+    if let Some(alpn) = socket.selected_protocol() {
+        let res = identify_alpn(alpn.as_bytes());
+        trace!("Identified connection via ALPN/websocket: {alpn:?} -> {res:?}");
+        return res;
+    }
+
+    let mut preface = [0; PREFACE_SIZE];
+    let mut read = 0;
+
+    // Read until we get PREFACE_SIZE bytes or at least MIN_PREFACE_SIZE bytes, the first four matching HTTP's style.
+    loop {
+        match socket.read(&mut preface[read..]).await {
+            Ok(0) => return Err(UnknownStreamType::Unknown),
+            Ok(n) => read += n,
+            Err(e) => {
+                trace!("Error while reading connection preface: {e:?}");
+                return Err(UnknownStreamType::Unknown);
+            }
+        }
+        if read == PREFACE_SIZE {
+            break;
+        }
+        // If we've read at least MIN_PREFACE_SIZE bytes and those five bytes are HTTP/1-like, we can continue here
+        // as we know the protocol will be HTTP/1 or HTTP/2.
+        if read >= MIN_PREFACE_SIZE {
+            let [a1, a2, a3, a4, ..] = preface;
+            if is_likely_http1(a1, a2, a3, a4) {
+                break;
+            }
+        }
+    }
+
+    // Rewind the stream
+    socket.rewind(&preface[..read]);
+
+    // Identify the connection
+    let res = identify_connection(state, &preface);
+    trace!(
+        "Identified connection via preface: {:?} -> {res:?}",
+        &preface[..read]
+    );
+    res
+}

--- a/gel-frontend/src/tower.rs
+++ b/gel-frontend/src/tower.rs
@@ -1,0 +1,8 @@
+// pub fn build_tower() -> impl tower::Service<hyper::http::Request<hyper::body::Incoming>> {
+//     ServiceBuilder::new()
+//         // Compress response bodies
+//         .compression()
+//         // Deconpress request bodies
+//         .decompression()
+//         .service_fn(f)
+// }


### PR DESCRIPTION
This is the initial implementation of "babelfish", a network frontend that speaks:

 - Gel/EdgeDB
 - PostgreSQL
 - HTTP 1/2
 - SSL
 - ... and potentially more

This crate deals with connection termination only. Authorization, authentication and actual stream handling are designed to be punted to other layers of the system.
