### PR TITLE
Improve gel-stream API and docs

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -5,7 +5,7 @@ name: CI
 jobs:
   build_and_test:
     name: Tests (Windows)
-    runs-on: large-win-x64
+    runs-on: windows-2025
     strategy:
       matrix:
         rust_version: [default]

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -5,7 +5,7 @@ name: CI
 jobs:
   build_and_test:
     name: Tests (Windows)
-    runs-on: windows-2025
+    runs-on: large-win-x64
     strategy:
       matrix:
         rust_version: [default]

--- a/gel-stream/Cargo.toml
+++ b/gel-stream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gel-stream"
 license = "MIT/Apache-2.0"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["MagicStack Inc. <hello@magic.io>"]
 edition = "2021"
 description = "A library for streaming data between clients and servers."
@@ -12,7 +12,7 @@ rust-version.workspace = true
 # rustls or openssl imply tokio, and tokio is the only stream we support
 # at this time.
 default = ["tokio"]
-full = ["client", "server", "tokio", "rustls", "openssl", "hickory", "keepalive"]
+full = ["client", "server", "tokio", "rustls", "openssl", "hickory", "keepalive", "pem"]
 client = []
 server = []
 serde = ["dep:serde"]
@@ -21,6 +21,7 @@ rustls = ["tokio", "dep:rustls", "dep:rustls-tokio-stream", "dep:rustls-platform
 openssl = ["tokio", "dep:openssl", "dep:tokio-openssl", "dep:foreign-types", "dep:openssl-sys", "dep:openssl-probe", "dep:webpki-root-certs"]
 hickory = ["dep:hickory-resolver"]
 keepalive = ["dep:socket2"]
+pem = ["dep:rustls-pemfile"]
 __manual_tests = []
 
 [dependencies]
@@ -38,27 +39,30 @@ socket2 = { version = "0.5.2", optional = true }
 
 # feature = "tokio"
 tokio = { version = "1", optional = true, default-features = false, features = ["net", "rt"] }
-hickory-resolver = { version = "0.24.2", optional = true, default-features = false, features = ["tokio-runtime", "system-config"] }
+hickory-resolver = { version = "0.25.2", optional = true, default-features = false, features = ["tokio", "system-config"] }
 
 # feature = "rustls"
 # We rely on certain aspects of these crates. Use caution when upgrading.
 rustls = { version = ">= 0.23.25", optional = true, default-features = false, features = ["ring", "logging", "std", "tls12"] }
-rustls-tokio-stream = { version = "0.5.0", optional = true }
+rustls-tokio-stream = { version = "0.6.0", optional = true }
 rustls-platform-verifier = { version = "0.5.1", optional = true }
 webpki = { version = "0.22", optional = true }
-webpki-roots = { version = "0.26.8", optional = true }
+webpki-roots = { version = "1", optional = true }
 
 # feature = "openssl"
-openssl = { version = "0.10.71", optional = true, default-features = false }
+openssl = { version = "0.10.72", optional = true, default-features = false }
 tokio-openssl = { version = "0.6.5", optional = true, default-features = false }
 # Get these from openssl
 foreign-types = { version = "0.3", optional = true, default-features = false }
 openssl-sys = { version = "0.9", optional = true, default-features = false }
 openssl-probe = { version = "0.1.6", optional = true, default-features = false }
-webpki-root-certs = { version = "0.26.8", optional = true }
+webpki-root-certs = { version = "1", optional = true }
 
 # feature = serde
 serde = { version = "1.0", optional = true }
+
+# feature = pem
+rustls-pemfile = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 openssl-sys = { version = "0.9", optional = true, default-features = false, features = ["vendored"] }
@@ -70,7 +74,6 @@ gel-stream = { path = ".", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tempfile = "3"
 ntest = "0.9.3"
-rustls-pemfile = "2"
 x509-parser = "0.17.0"
 
 [lints]
@@ -78,3 +81,6 @@ workspace = true
 
 [lib]
 name = "gel_stream"
+
+[package.metadata.docs.rs]
+features = ["full"]

--- a/gel-stream/README.md
+++ b/gel-stream/README.md
@@ -40,7 +40,7 @@ use futures::TryStreamExt;
 #[tokio::main]
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Create a server that listens on all interfaces on a random port.
-    let acceptor = Acceptor::new_tcp(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0));
+    let acceptor = Acceptor::new_tcp(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0));
     let mut server = acceptor.bind().await?;
     let addr = server.local_address()?;
 
@@ -84,7 +84,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         include_bytes!("../tests/certs/server.cert.pem"),
     )?);
     let acceptor = Acceptor::new_tcp_tls(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         TlsServerParameterProvider::new(tls_params),
     );
     let mut server = acceptor.bind().await?;

--- a/gel-stream/README.md
+++ b/gel-stream/README.md
@@ -1,19 +1,115 @@
 # gel-stream
 
-This crate provides a runtime and TLS agnostic client and serverstream API for
-the EdgeDB server.
+This crate provides a runtime and TLS agnostic client and server stream API for
+services requiring TCP/Unix socket, plaintext, TLS, and STARTTLS connections.
+
+The crate may be used with either an OpenSSL or Rustls TLS implementation
+without changing the API.
 
 ## Features
 
-- `full`: Enable all features.
+- `full`: Enable all features (not recommended).
 - `openssl`: Enable OpenSSL support.
 - `rustls`: Enable Rustls support.
-- `tokio`: Enable Tokio support.
+- `tokio`: Enable Tokio support (default).
 - `hickory`: Enable Hickory support.
 - `keepalive`: Enable keepalive support.
+- `serde`: Enable serde serialization support for most types.
+- `pem`: Enable PEM support for TLS parameters.
 
 ## TLS
 
 TLS is supported via the `openssl` or `rustls` features. Regardless of which TLS
 library is used, the API is the same.
 
+## Usage
+
+The crate provides a `Target` and `Connector` for clients and a `Acceptor` for
+servers.
+
+### Examples
+
+Creating and connecting to a TCP server:
+
+```rust
+use gel_stream::*;
+use std::net::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use futures::TryStreamExt;
+
+#[tokio::main]
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a server that listens on all interfaces on a random port.
+    let acceptor = Acceptor::new_tcp(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0));
+    let mut server = acceptor.bind().await?;
+    let addr = server.local_address()?;
+
+    /// When creating servers, clients and servers should be run in separate tasks.
+    let task1 = tokio::spawn(async move {
+        let mut server_conn = server.try_next().await?.expect("Didn't get a connection");
+        server_conn.write_all(b"Hello, world!").await?;
+        std::io::Result::Ok(())
+    });
+
+    let task2 = tokio::spawn(async move {
+        let mut client_conn = Connector::new(Target::new_resolved(addr))?.connect().await?;
+        let mut buffer = String::new();
+        client_conn.read_to_string(&mut buffer).await?;
+        assert_eq!(buffer, "Hello, world!");
+        std::io::Result::Ok(())
+    });
+
+    task1.await??;
+    task2.await??;
+
+    Ok(())
+}
+
+# run().expect("failed to run example!");
+```
+
+Creating a TLS server with a given key and certificate, and connecting to it:
+
+```rust
+use gel_stream::*;
+use std::net::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use futures::TryStreamExt;
+
+#[tokio::main]
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a server that listens on all interfaces on a random port.
+    let tls_params = TlsServerParameters::new_with_certificate(TlsKey::new_pem(
+        include_bytes!("../tests/certs/server.key.pem"),
+        include_bytes!("../tests/certs/server.cert.pem"),
+    )?);
+    let acceptor = Acceptor::new_tcp_tls(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        TlsServerParameterProvider::new(tls_params),
+    );
+    let mut server = acceptor.bind().await?;
+    let addr = server.local_address()?;
+
+    /// When creating servers, clients and servers should be run in separate tasks.
+    let task1 = tokio::spawn(async move {
+        let mut server_conn = server.try_next().await?.expect("Didn't get a connection");
+        server_conn.write_all(b"Hello, world!").await?;
+        std::io::Result::Ok(())
+    });
+
+    let task2 = tokio::spawn(async move {
+        let mut client_conn = Connector::new(Target::new_resolved_tls(addr, TlsParameters::insecure()))?.connect().await?;
+        let mut buffer = String::new();
+        client_conn.read_to_string(&mut buffer).await?;
+        assert_eq!(buffer, "Hello, world!");
+        std::io::Result::Ok(())
+    });
+
+    task1.await??;
+    task2.await??;
+
+    Ok(())
+}
+
+# run().expect("failed to run example!");
+```

--- a/gel-stream/src/common/mod.rs
+++ b/gel-stream/src/common/mod.rs
@@ -9,8 +9,10 @@ pub mod rustls;
 #[cfg(feature = "tokio")]
 pub mod tokio_stream;
 
+#[doc(hidden)]
 #[cfg(feature = "tokio")]
 pub type BaseStream = tokio_stream::TokioStream;
 
+#[doc(hidden)]
 #[cfg(not(feature = "tokio"))]
 pub type BaseStream = ();

--- a/gel-stream/src/common/rustls.rs
+++ b/gel-stream/src/common/rustls.rs
@@ -14,7 +14,7 @@ use rustls_tokio_stream::TlsStream;
 
 use super::tokio_stream::TokioStream;
 use crate::{
-    RewindStream, SslError, Stream, TlsClientCertVerify, TlsDriver, TlsHandshake,
+    RewindStream, SslError, SslVersion, Stream, TlsClientCertVerify, TlsDriver, TlsHandshake,
     TlsServerParameterProvider, TlsServerParameters,
 };
 use crate::{TlsCert, TlsParameters, TlsServerCertVerify};
@@ -142,12 +142,20 @@ impl TlsDriver for RustlsDriver {
                     .connection()
                     .and_then(|c| c.peer_certificates())
                     .and_then(|c| c.first().map(|cert| cert.to_owned()));
+                let version = stream.connection().and_then(|c| c.protocol_version());
                 Ok((
                     stream,
                     TlsHandshake {
                         alpn: handshake.alpn.map(|alpn| Cow::Owned(alpn.to_vec())),
                         sni: handshake.sni.map(|sni| Cow::Owned(sni.to_string())),
                         cert,
+                        version: match version {
+                            Some(rustls::ProtocolVersion::TLSv1_0) => Some(SslVersion::Tls1),
+                            Some(rustls::ProtocolVersion::TLSv1_1) => Some(SslVersion::Tls1_1),
+                            Some(rustls::ProtocolVersion::TLSv1_2) => Some(SslVersion::Tls1_2),
+                            Some(rustls::ProtocolVersion::TLSv1_3) => Some(SslVersion::Tls1_3),
+                            _ => None,
+                        },
                     },
                 ))
             }
@@ -205,12 +213,20 @@ impl TlsDriver for RustlsDriver {
                     .connection()
                     .and_then(|c| c.peer_certificates())
                     .and_then(|c| c.first().map(|cert| cert.to_owned()));
+                let version = stream.connection().and_then(|c| c.protocol_version());
                 Ok((
                     stream,
                     TlsHandshake {
                         alpn: handshake.alpn.map(|alpn| Cow::Owned(alpn.to_vec())),
                         sni: handshake.sni.map(|sni| Cow::Owned(sni.to_string())),
                         cert,
+                        version: match version {
+                            Some(rustls::ProtocolVersion::TLSv1_0) => Some(SslVersion::Tls1),
+                            Some(rustls::ProtocolVersion::TLSv1_1) => Some(SslVersion::Tls1_1),
+                            Some(rustls::ProtocolVersion::TLSv1_2) => Some(SslVersion::Tls1_2),
+                            Some(rustls::ProtocolVersion::TLSv1_3) => Some(SslVersion::Tls1_3),
+                            _ => None,
+                        },
                     },
                 ))
             }

--- a/gel-stream/src/common/stream.rs
+++ b/gel-stream/src/common/stream.rs
@@ -12,6 +12,7 @@ use std::{
 
 use crate::{Ssl, SslError, TlsDriver, TlsHandshake, TlsServerParameterProvider};
 
+/// A convenience trait for streams from this crate.
 #[cfg(feature = "tokio")]
 pub trait Stream: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static {
     fn downcast<S: Stream + 'static>(self) -> Result<S, Self>
@@ -39,6 +40,7 @@ impl<S: Stream, D: TlsDriver> Stream for UpgradableStream<S, D> {}
 #[cfg(not(feature = "tokio"))]
 impl Stream for () {}
 
+/// A trait for streams that can be upgraded to a TLS stream.
 pub trait StreamUpgrade: Stream {
     fn secure_upgrade(&mut self) -> impl Future<Output = Result<(), SslError>> + Send;
     fn handshake(&self) -> Option<&TlsHandshake>;

--- a/gel-stream/src/common/target.rs
+++ b/gel-stream/src/common/target.rs
@@ -135,6 +135,8 @@ impl TargetName {
     }
 }
 
+/// A target describes the TCP or Unix socket that a client will connect to,
+/// along with any optional TLS parameters.
 #[derive(Clone)]
 pub struct Target {
     inner: TargetInner,
@@ -510,6 +512,7 @@ impl ResolvedTarget {
     }
 }
 
+/// A trait for types that have a local address.
 pub trait LocalAddress {
     fn local_address(&self) -> std::io::Result<ResolvedTarget>;
 }

--- a/gel-stream/src/common/tokio_stream.rs
+++ b/gel-stream/src/common/tokio_stream.rs
@@ -12,7 +12,7 @@ use super::target::{LocalAddress, ResolvedTarget};
 
 pub(crate) struct Resolver {
     #[cfg(feature = "hickory")]
-    resolver: hickory_resolver::TokioAsyncResolver,
+    resolver: hickory_resolver::TokioResolver,
 }
 
 #[allow(unused)]
@@ -33,7 +33,7 @@ impl Resolver {
     pub fn new() -> Result<Self, std::io::Error> {
         Ok(Self {
             #[cfg(feature = "hickory")]
-            resolver: hickory_resolver::AsyncResolver::tokio_from_system_conf()?,
+            resolver: hickory_resolver::Resolver::builder_tokio()?.build(),
         })
     }
 

--- a/gel-stream/src/server/acceptor.rs
+++ b/gel-stream/src/server/acceptor.rs
@@ -20,6 +20,30 @@ pub struct Acceptor {
 }
 
 impl Acceptor {
+    pub fn new(target: ResolvedTarget) -> Self {
+        Self {
+            resolved_target: target,
+            tls_provider: None,
+            should_upgrade: false,
+        }
+    }
+
+    pub fn new_tls(target: ResolvedTarget, provider: TlsServerParameterProvider) -> Self {
+        Self {
+            resolved_target: target,
+            tls_provider: Some(provider),
+            should_upgrade: true,
+        }
+    }
+
+    pub fn new_starttls(target: ResolvedTarget, provider: TlsServerParameterProvider) -> Self {
+        Self {
+            resolved_target: target,
+            tls_provider: Some(provider),
+            should_upgrade: false,
+        }
+    }
+
     pub fn new_tcp(addr: SocketAddr) -> Self {
         Self {
             resolved_target: ResolvedTarget::SocketAddr(addr),

--- a/gel-stream/tests/tls.rs
+++ b/gel-stream/tests/tls.rs
@@ -92,6 +92,7 @@ async fn spawn_tls_server<S: TlsDriver>(
         let handshake = connection
             .handshake()
             .unwrap_or_else(|| panic!("handshake was not available on {connection:?}"));
+        assert!(handshake.version.is_some());
         assert_eq!(
             handshake.alpn.as_ref().map(|b| b.as_ref().to_vec()),
             expected_alpn

--- a/gel-tokio/Cargo.toml
+++ b/gel-tokio/Cargo.toml
@@ -17,7 +17,7 @@ gel-protocol = { path = "../gel-protocol", version = "^0.8.3", features = [
 ] }
 gel-errors = { path = "../gel-errors", version = "^0.5.2" }
 gel-derive = { path = "../gel-derive", version = "^0.7.2", optional = true }
-gel-stream = { path = "../gel-stream", version = "^0.3.2", features = ["client", "tokio", "rustls", "hickory", "keepalive"] }
+gel-stream = { path = "../gel-stream", version = "^0.4.0", features = ["client", "tokio", "rustls", "hickory", "keepalive"] }
 gel-dsn = { path = "../gel-dsn", version = "^0.2.13", features = ["gel", "log", "auto-log-trace", "auto-log-warning"] }
 gel-auth = { path = "../gel-auth", version = "^0.1.5" }
 tokio = { workspace = true, features = ["net", "time", "sync", "macros"] }


### PR DESCRIPTION
The gel-stream API is simple, but needs a gentle introduction for the reader. This adds an example to the README and fleshes out the docs.

We also bump some deps and expose the SSL version in the handshake, which we'll need for later on.