### PR TITLE
Ignore missing CLOSE_NOTIFY

### DIFF
--- a/gel-stream/src/common/rustls.rs
+++ b/gel-stream/src/common/rustls.rs
@@ -29,6 +29,7 @@ impl TlsDriver for RustlsDriver {
     type Stream = TlsStream;
     type ClientParams = ClientConnection;
     type ServerParams = Arc<ServerConfig>;
+    const DRIVER_NAME: &'static str = "rustls";
 
     fn init_client(
         params: &TlsParameters,
@@ -242,6 +243,11 @@ impl TlsDriver for RustlsDriver {
                 }
             }
         }
+    }
+
+    fn unclean_shutdown(this: Self::Stream) -> Result<(), Self::Stream> {
+        // Skip the shutdown logic by tearing this down into its parts.
+        this.try_into_inner().map(drop)
     }
 }
 

--- a/gel-tokio/src/raw/connection.rs
+++ b/gel-tokio/src/raw/connection.rs
@@ -295,6 +295,10 @@ async fn connect2(
 ) -> Result<Connection, Error> {
     let mut connector = Connector::new(target.clone()).map_err(ClientConnectionError::with_source)?;
     connector.set_keepalive(cfg.tcp_keepalive.as_keepalive());
+    // Ignore missing close notify on Windows. This is unfortunately reasonably
+    // common on that platform.
+    #[cfg(windows)]
+    connector.ignore_missing_tls_close_notify();
     let mut res = connector.connect().await;
 
     // Allow plaintext reconnection if and only if ClientSecurity is InsecureDevMode and


### PR DESCRIPTION
On Windows, if a FIN is received on a socket before CLOSE_NOTIFY has been processed, the Rustls client may believe that the server failed to send it when in fact, it was dropped by WinSock because EOF on a TCP stream throws away the read buffer.

We add an option to ignore the missing close_notify and thread it through the gel-stream library. This is only enable on Windows.