### PR TITLE
Log the partial message in EOS

### DIFF
--- a/gel-stream/src/common/stream.rs
+++ b/gel-stream/src/common/stream.rs
@@ -172,7 +172,6 @@ impl<S: Stream, D: TlsDriver> tokio::io::AsyncRead for UpgradableStream<S, D> {
         if ignore_missing_close_notify {
             if matches!(res, std::task::Poll::Ready(Err(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof)
             {
-                eprintln!("Unexpected EOF");
                 return std::task::Poll::Ready(Ok(()));
             }
         }

--- a/gel-tokio/src/raw/connection.rs
+++ b/gel-tokio/src/raw/connection.rs
@@ -688,7 +688,7 @@ async fn _wait_message(
         buf.reserve(5);
         if _read_buf(stream, buf).await.map_err(conn_err)? == 0 {
             return Err(ClientConnectionEosError::with_message(
-                "end of stream while reading message",
+                format!("end of stream while reading message (received {buf:?} <eof>)"),
             ));
         }
     }
@@ -699,7 +699,9 @@ async fn _wait_message(
         buf.reserve(frame_len - buf.len());
         if _read_buf(stream, buf).await.map_err(conn_err)? == 0 {
             return Err(ClientConnectionEosError::with_message(
-                "end of stream while reading message",
+                format!("end of stream while reading message (received {buf:?} <{n} bytes> <eof>)",
+                buf=&buf[..5],
+                n=buf.len() - 5),
             ));
         }
     }


### PR DESCRIPTION
This might help us debug the Windows EOS issues. Hopefully we'll see what partial message exists.