### PR TITLE
Implement previewable streams

### DIFF
--- a/gel-stream/Cargo.toml
+++ b/gel-stream/Cargo.toml
@@ -25,9 +25,10 @@ pem = ["dep:rustls-pemfile"]
 __manual_tests = []
 
 [dependencies]
-derive_more = { version = "2", features = ["full"] }
+derive_more = { version = "2", default-features = false, features = ["debug", "constructor", "from", "display", "error"] }
 thiserror = "2"
 futures = "0.3"
+smallvec = "1"
 
 # Given that this library may be used in multiple contexts, we want to limit the
 # features we enable by default.
@@ -66,6 +67,9 @@ rustls-pemfile = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 openssl-sys = { version = "0.9", optional = true, default-features = false, features = ["vendored"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 # Run tests with all features enabled

--- a/gel-stream/src/common/stream.rs
+++ b/gel-stream/src/common/stream.rs
@@ -1,7 +1,7 @@
+use tokio::io::AsyncReadExt;
 #[cfg(feature = "tokio")]
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use std::future::Future;
 #[cfg(feature = "tokio")]
 use std::{
     any::Any,
@@ -9,8 +9,11 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+use std::{future::Future, num::NonZeroUsize, ops::Deref};
 
-use crate::{Ssl, SslError, TlsDriver, TlsHandshake, TlsServerParameterProvider};
+use crate::{
+    Ssl, SslError, TlsDriver, TlsHandshake, TlsServerParameterProvider, DEFAULT_PREVIEW_BUFFER_SIZE,
+};
 
 /// A convenience trait for streams from this crate.
 #[cfg(feature = "tokio")]
@@ -42,8 +45,97 @@ impl Stream for () {}
 
 /// A trait for streams that can be upgraded to a TLS stream.
 pub trait StreamUpgrade: Stream {
+    /// Upgrade the stream to a TLS stream.
     fn secure_upgrade(&mut self) -> impl Future<Output = Result<(), SslError>> + Send;
+    /// Upgrade the stream to a TLS stream, and preview the initial bytes.
+    fn secure_upgrade_preview(
+        &mut self,
+        options: PreviewConfiguration,
+    ) -> impl Future<Output = Result<Preview, SslError>> + Send;
+    /// Get the TLS handshake information, if the stream is upgraded.
     fn handshake(&self) -> Option<&TlsHandshake>;
+}
+
+/// A trait for streams that can be peeked asynchronously.
+pub trait PeekableStream: Stream {
+    #[cfg(feature = "tokio")]
+    fn poll_peek(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf,
+    ) -> Poll<std::io::Result<usize>>;
+    #[cfg(feature = "tokio")]
+    fn peek(self: Pin<&mut Self>, buf: &mut [u8]) -> impl Future<Output = std::io::Result<usize>> {
+        async {
+            let mut this = self;
+            std::future::poll_fn(move |cx| this.as_mut().poll_peek(cx, &mut ReadBuf::new(buf)))
+                .await
+        }
+    }
+}
+
+/// A preview of the initial bytes of the stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub struct Preview {
+    buffer: smallvec::SmallVec<[u8; DEFAULT_PREVIEW_BUFFER_SIZE as usize]>,
+}
+
+impl Preview {
+    pub(crate) fn new(
+        buffer: smallvec::SmallVec<[u8; DEFAULT_PREVIEW_BUFFER_SIZE as usize]>,
+    ) -> Self {
+        Self { buffer }
+    }
+}
+
+impl Deref for Preview {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.buffer
+    }
+}
+
+impl AsRef<[u8]> for Preview {
+    fn as_ref(&self) -> &[u8] {
+        &self.buffer
+    }
+}
+
+impl<const N: usize> PartialEq<[u8; N]> for Preview {
+    fn eq(&self, other: &[u8; N]) -> bool {
+        self.buffer.as_slice() == other
+    }
+}
+
+impl<const N: usize> PartialEq<&[u8; N]> for Preview {
+    fn eq(&self, other: &&[u8; N]) -> bool {
+        self.buffer.as_slice() == *other
+    }
+}
+
+impl PartialEq<[u8]> for Preview {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.buffer.as_slice() == other
+    }
+}
+
+/// Configuration for the initial preview of the client connection.
+#[derive(Debug, Clone, Copy)]
+pub struct PreviewConfiguration {
+    /// The maximum number of bytes to preview. Recommended value is 8 bytes.
+    pub max_preview_bytes: NonZeroUsize,
+    /// The maximum duration to preview for. Recommended value is 10 seconds.
+    pub max_preview_duration: std::time::Duration,
+}
+
+impl Default for PreviewConfiguration {
+    fn default() -> Self {
+        Self {
+            max_preview_bytes: NonZeroUsize::new(DEFAULT_PREVIEW_BUFFER_SIZE as usize).unwrap(),
+            max_preview_duration: std::time::Duration::from_secs(10),
+        }
+    }
 }
 
 #[derive(Default, Debug)]
@@ -76,12 +168,25 @@ impl<S: Stream, D: TlsDriver> UpgradableStream<S, D> {
         }
     }
 
+    #[inline(always)]
+    pub(crate) fn new_server_preview(
+        base: RewindStream<S>,
+        config: Option<TlsServerParameterProvider>,
+    ) -> Self {
+        UpgradableStream {
+            inner: UpgradableStreamInner::BaseServerPreview(base, config),
+            options: Default::default(),
+        }
+    }
+
     /// Consume the `UpgradableStream` and return the underlying stream as a [`Box<dyn Stream>`].
     pub fn into_boxed(self) -> Result<Box<dyn Stream>, Self> {
         match self.inner {
             UpgradableStreamInner::BaseClient(base, _) => Ok(Box::new(base)),
             UpgradableStreamInner::BaseServer(base, _) => Ok(Box::new(base)),
+            UpgradableStreamInner::BaseServerPreview(base, _) => Ok(Box::new(base)),
             UpgradableStreamInner::Upgraded(upgraded, _) => Ok(Box::new(upgraded)),
+            UpgradableStreamInner::UpgradedPreview(upgraded, _) => Ok(Box::new(upgraded)),
             UpgradableStreamInner::Upgrading => Err(self),
         }
     }
@@ -103,10 +208,28 @@ impl<S: Stream, D: TlsDriver> UpgradableStream<S, D> {
         match self.inner {
             UpgradableStreamInner::BaseClient(..) => Ok(()),
             UpgradableStreamInner::BaseServer(..) => Ok(()),
+            UpgradableStreamInner::BaseServerPreview(..) => Ok(()),
             UpgradableStreamInner::Upgraded(upgraded, cfg) => {
                 if let Err(e) = D::unclean_shutdown(upgraded) {
                     Err(Self {
                         inner: UpgradableStreamInner::Upgraded(e, cfg),
+                        options: self.options,
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+            UpgradableStreamInner::UpgradedPreview(upgraded, cfg) => {
+                let (stm, buf) = upgraded.into_inner();
+                if let Err(e) = D::unclean_shutdown(stm) {
+                    Err(Self {
+                        inner: UpgradableStreamInner::UpgradedPreview(
+                            RewindStream {
+                                buffer: buf,
+                                inner: e,
+                            },
+                            cfg,
+                        ),
                         options: self.options,
                     })
                 } else {
@@ -118,29 +241,76 @@ impl<S: Stream, D: TlsDriver> UpgradableStream<S, D> {
     }
 }
 
-impl<S: Stream + Send, D: TlsDriver> StreamUpgrade for UpgradableStream<S, D> {
+impl<S: Stream, D: TlsDriver> StreamUpgrade for UpgradableStream<S, D> {
     fn secure_upgrade(&mut self) -> impl Future<Output = Result<(), SslError>> + Send {
-        async {
-            match std::mem::replace(&mut self.inner, UpgradableStreamInner::Upgrading) {
-                UpgradableStreamInner::BaseClient(base, config) => {
-                    let Some(config) = config else {
-                        return Err(SslError::SslUnsupportedByClient);
-                    };
-                    let (upgraded, handshake) = D::upgrade_client(config, base).await?;
-                    self.inner = UpgradableStreamInner::Upgraded(upgraded, handshake);
-                    Ok(())
-                }
-                UpgradableStreamInner::BaseServer(base, config) => {
-                    let Some(config) = config else {
-                        return Err(SslError::SslUnsupportedByClient);
-                    };
-                    let (upgraded, handshake) = D::upgrade_server(config, base).await?;
-                    self.inner = UpgradableStreamInner::Upgraded(upgraded, handshake);
-                    Ok(())
-                }
-                UpgradableStreamInner::Upgraded(..) => Err(SslError::SslAlreadyUpgraded),
-                UpgradableStreamInner::Upgrading => Err(SslError::SslAlreadyUpgraded),
-            }
+        async move {
+            let (upgraded, handshake) =
+                match std::mem::replace(&mut self.inner, UpgradableStreamInner::Upgrading) {
+                    UpgradableStreamInner::BaseClient(base, config) => {
+                        let Some(config) = config else {
+                            return Err(SslError::SslUnsupported);
+                        };
+                        D::upgrade_client(config, base).await?
+                    }
+                    UpgradableStreamInner::BaseServer(base, config) => {
+                        let Some(config) = config else {
+                            return Err(SslError::SslUnsupported);
+                        };
+                        D::upgrade_server(config, base).await?
+                    }
+                    UpgradableStreamInner::BaseServerPreview(base, config) => {
+                        let Some(config) = config else {
+                            return Err(SslError::SslUnsupported);
+                        };
+                        D::upgrade_server(config, base).await?
+                    }
+                    other => {
+                        self.inner = other;
+                        return Err(SslError::SslAlreadyUpgraded);
+                    }
+                };
+            self.inner = UpgradableStreamInner::Upgraded(upgraded, handshake);
+            Ok(())
+        }
+    }
+
+    fn secure_upgrade_preview(
+        &mut self,
+        options: PreviewConfiguration,
+    ) -> impl Future<Output = Result<Preview, SslError>> + Send {
+        async move {
+            let (mut upgraded, handshake) =
+                match std::mem::replace(&mut self.inner, UpgradableStreamInner::Upgrading) {
+                    UpgradableStreamInner::BaseClient(base, config) => {
+                        let Some(config) = config else {
+                            return Err(SslError::SslUnsupported);
+                        };
+                        D::upgrade_client(config, base).await?
+                    }
+                    UpgradableStreamInner::BaseServer(base, config) => {
+                        let Some(config) = config else {
+                            return Err(SslError::SslUnsupported);
+                        };
+                        D::upgrade_server(config, base).await?
+                    }
+                    UpgradableStreamInner::BaseServerPreview(base, config) => {
+                        let Some(config) = config else {
+                            return Err(SslError::SslUnsupported);
+                        };
+                        D::upgrade_server(config, base).await?
+                    }
+                    other => {
+                        self.inner = other;
+                        return Err(SslError::SslAlreadyUpgraded);
+                    }
+                };
+            let mut buffer = smallvec::SmallVec::with_capacity(options.max_preview_bytes.get());
+            buffer.resize(options.max_preview_bytes.get(), 0);
+            upgraded.read_exact(&mut buffer).await?;
+            let mut rewind = RewindStream::new(upgraded);
+            rewind.rewind(&buffer);
+            self.inner = UpgradableStreamInner::UpgradedPreview(rewind, handshake);
+            Ok(Preview { buffer })
         }
     }
 
@@ -165,7 +335,11 @@ impl<S: Stream, D: TlsDriver> tokio::io::AsyncRead for UpgradableStream<S, D> {
         let res = match inner {
             UpgradableStreamInner::BaseClient(base, _) => Pin::new(base).poll_read(cx, buf),
             UpgradableStreamInner::BaseServer(base, _) => Pin::new(base).poll_read(cx, buf),
+            UpgradableStreamInner::BaseServerPreview(base, _) => Pin::new(base).poll_read(cx, buf),
             UpgradableStreamInner::Upgraded(upgraded, _) => Pin::new(upgraded).poll_read(cx, buf),
+            UpgradableStreamInner::UpgradedPreview(upgraded, _) => {
+                Pin::new(upgraded).poll_read(cx, buf)
+            }
             UpgradableStreamInner::Upgrading => std::task::Poll::Ready(Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "Cannot read while upgrading",
@@ -193,7 +367,11 @@ impl<S: Stream, D: TlsDriver> tokio::io::AsyncWrite for UpgradableStream<S, D> {
         match inner {
             UpgradableStreamInner::BaseClient(base, _) => Pin::new(base).poll_write(cx, buf),
             UpgradableStreamInner::BaseServer(base, _) => Pin::new(base).poll_write(cx, buf),
+            UpgradableStreamInner::BaseServerPreview(base, _) => Pin::new(base).poll_write(cx, buf),
             UpgradableStreamInner::Upgraded(upgraded, _) => Pin::new(upgraded).poll_write(cx, buf),
+            UpgradableStreamInner::UpgradedPreview(upgraded, _) => {
+                Pin::new(upgraded).poll_write(cx, buf)
+            }
             UpgradableStreamInner::Upgrading => std::task::Poll::Ready(Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "Cannot write while upgrading",
@@ -210,7 +388,11 @@ impl<S: Stream, D: TlsDriver> tokio::io::AsyncWrite for UpgradableStream<S, D> {
         match inner {
             UpgradableStreamInner::BaseClient(base, _) => Pin::new(base).poll_flush(cx),
             UpgradableStreamInner::BaseServer(base, _) => Pin::new(base).poll_flush(cx),
+            UpgradableStreamInner::BaseServerPreview(base, _) => Pin::new(base).poll_flush(cx),
             UpgradableStreamInner::Upgraded(upgraded, _) => Pin::new(upgraded).poll_flush(cx),
+            UpgradableStreamInner::UpgradedPreview(upgraded, _) => {
+                Pin::new(upgraded).poll_flush(cx)
+            }
             UpgradableStreamInner::Upgrading => std::task::Poll::Ready(Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "Cannot flush while upgrading",
@@ -227,7 +409,11 @@ impl<S: Stream, D: TlsDriver> tokio::io::AsyncWrite for UpgradableStream<S, D> {
         match inner {
             UpgradableStreamInner::BaseClient(base, _) => Pin::new(base).poll_shutdown(cx),
             UpgradableStreamInner::BaseServer(base, _) => Pin::new(base).poll_shutdown(cx),
+            UpgradableStreamInner::BaseServerPreview(base, _) => Pin::new(base).poll_shutdown(cx),
             UpgradableStreamInner::Upgraded(upgraded, _) => Pin::new(upgraded).poll_shutdown(cx),
+            UpgradableStreamInner::UpgradedPreview(upgraded, _) => {
+                Pin::new(upgraded).poll_shutdown(cx)
+            }
             UpgradableStreamInner::Upgrading => std::task::Poll::Ready(Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "Cannot shutdown while upgrading",
@@ -240,7 +426,9 @@ impl<S: Stream, D: TlsDriver> tokio::io::AsyncWrite for UpgradableStream<S, D> {
         match &self.inner {
             UpgradableStreamInner::BaseClient(base, _) => base.is_write_vectored(),
             UpgradableStreamInner::BaseServer(base, _) => base.is_write_vectored(),
+            UpgradableStreamInner::BaseServerPreview(base, _) => base.is_write_vectored(),
             UpgradableStreamInner::Upgraded(upgraded, _) => upgraded.is_write_vectored(),
+            UpgradableStreamInner::UpgradedPreview(upgraded, _) => upgraded.is_write_vectored(),
             UpgradableStreamInner::Upgrading => false,
         }
     }
@@ -259,7 +447,13 @@ impl<S: Stream, D: TlsDriver> tokio::io::AsyncWrite for UpgradableStream<S, D> {
             UpgradableStreamInner::BaseServer(base, _) => {
                 Pin::new(base).poll_write_vectored(cx, bufs)
             }
+            UpgradableStreamInner::BaseServerPreview(base, _) => {
+                Pin::new(base).poll_write_vectored(cx, bufs)
+            }
             UpgradableStreamInner::Upgraded(upgraded, _) => {
+                Pin::new(upgraded).poll_write_vectored(cx, bufs)
+            }
+            UpgradableStreamInner::UpgradedPreview(upgraded, _) => {
                 Pin::new(upgraded).poll_write_vectored(cx, bufs)
             }
             UpgradableStreamInner::Upgrading => std::task::Poll::Ready(Err(std::io::Error::new(
@@ -276,8 +470,12 @@ enum UpgradableStreamInner<S: Stream, D: TlsDriver> {
     BaseClient(S, Option<D::ClientParams>),
     #[debug("BaseServer(..)")]
     BaseServer(S, Option<TlsServerParameterProvider>),
+    #[debug("Preview(..)")]
+    BaseServerPreview(RewindStream<S>, Option<TlsServerParameterProvider>),
     #[debug("Upgraded(..)")]
     Upgraded(D::Stream, TlsHandshake),
+    #[debug("Upgraded(..)")]
+    UpgradedPreview(RewindStream<D::Stream>, TlsHandshake),
     #[debug("Upgrading")]
     Upgrading,
 }
@@ -286,7 +484,8 @@ pub trait Rewindable {
     fn rewind(&mut self, bytes: &[u8]) -> std::io::Result<()>;
 }
 
-pub struct RewindStream<S> {
+/// A stream that can be rewound.
+pub(crate) struct RewindStream<S> {
     buffer: Vec<u8>,
     inner: S,
 }
@@ -376,6 +575,22 @@ impl<S: Stream> Rewindable for RewindStream<S> {
     }
 }
 
+impl<S: PeekableStream> PeekableStream for RewindStream<S> {
+    fn poll_peek(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<usize>> {
+        if !self.buffer.is_empty() {
+            let to_read = std::cmp::min(buf.remaining(), self.buffer.len());
+            buf.put_slice(&self.buffer[..to_read]);
+            Poll::Ready(Ok(to_read))
+        } else {
+            Pin::new(&mut self.inner).poll_peek(cx, buf)
+        }
+    }
+}
+
 impl<S: Stream + Rewindable, D: TlsDriver> Rewindable for UpgradableStream<S, D>
 where
     D::Stream: Rewindable,
@@ -384,11 +599,39 @@ where
         match &mut self.inner {
             UpgradableStreamInner::BaseClient(stm, _) => stm.rewind(bytes),
             UpgradableStreamInner::BaseServer(stm, _) => stm.rewind(bytes),
+            UpgradableStreamInner::BaseServerPreview(stm, _) => Ok(stm.rewind(bytes)),
             UpgradableStreamInner::Upgraded(stm, _) => stm.rewind(bytes),
+            UpgradableStreamInner::UpgradedPreview(stm, _) => Ok(stm.rewind(bytes)),
             UpgradableStreamInner::Upgrading => Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,
                 "Cannot rewind a stream that is upgrading",
             )),
+        }
+    }
+}
+
+impl<S: PeekableStream, D: TlsDriver> PeekableStream for UpgradableStream<S, D>
+where
+    D::Stream: PeekableStream,
+{
+    #[cfg(feature = "tokio")]
+    fn poll_peek(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf,
+    ) -> Poll<std::io::Result<usize>> {
+        match &mut self.get_mut().inner {
+            UpgradableStreamInner::BaseClient(base, _) => Pin::new(base).poll_peek(cx, buf),
+            UpgradableStreamInner::BaseServer(base, _) => Pin::new(base).poll_peek(cx, buf),
+            UpgradableStreamInner::BaseServerPreview(base, _) => Pin::new(base).poll_peek(cx, buf),
+            UpgradableStreamInner::Upgraded(upgraded, _) => Pin::new(upgraded).poll_peek(cx, buf),
+            UpgradableStreamInner::UpgradedPreview(upgraded, _) => {
+                Pin::new(upgraded).poll_peek(cx, buf)
+            }
+            UpgradableStreamInner::Upgrading => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "Cannot peek a stream that is upgrading",
+            ))),
         }
     }
 }

--- a/gel-stream/src/lib.rs
+++ b/gel-stream/src/lib.rs
@@ -30,6 +30,13 @@ pub use rustls_pki_types as pki_types;
 
 pub type RawStream = UpgradableStream<BaseStream>;
 
+/// The default TCP backlog for the server.
+pub const DEFAULT_TCP_BACKLOG: u32 = 1024;
+/// The default TLS backlog for the server.
+pub const DEFAULT_TLS_BACKLOG: u32 = 128;
+/// The default preview buffer size for the server.
+pub const DEFAULT_PREVIEW_BUFFER_SIZE: u32 = 8;
+
 #[derive(Debug, thiserror::Error)]
 pub enum ConnectionError {
     /// I/O error encountered during connection operations.
@@ -57,8 +64,8 @@ impl From<ConnectionError> for std::io::Error {
 
 #[derive(Debug, thiserror::Error)]
 pub enum SslError {
-    #[error("SSL is not supported by this client transport")]
-    SslUnsupportedByClient,
+    #[error("SSL is not supported by this transport")]
+    SslUnsupported,
     #[error("SSL is already upgraded or is in the process of upgrading")]
     SslAlreadyUpgraded,
 

--- a/gel-stream/src/server/acceptor.rs
+++ b/gel-stream/src/server/acceptor.rs
@@ -1,32 +1,52 @@
 use crate::{
-    common::tokio_stream::TokioListenerStream, ConnectionError, LocalAddress, ResolvedTarget,
-    RewindStream, Ssl, SslError, StreamUpgrade, TlsDriver, TlsServerParameterProvider,
-    UpgradableStream,
+    common::tokio_stream::TokioListenerStream, ConnectionError, LocalAddress, Preview,
+    PreviewConfiguration, ResolvedTarget, RewindStream, Ssl, StreamUpgrade, TlsDriver,
+    TlsServerParameterProvider, UpgradableStream, DEFAULT_TLS_BACKLOG,
 };
-use futures::{FutureExt, StreamExt};
+use futures::{stream::FuturesUnordered, StreamExt};
 use std::{
     future::Future,
     pin::Pin,
     task::{ready, Poll},
 };
 use std::{net::SocketAddr, path::Path};
+use tokio::io::AsyncReadExt;
 
-use super::Connection;
+type Connection<D = Ssl> = UpgradableStream<crate::BaseStream, D>;
 
-pub struct Acceptor {
+pub struct Acceptor<const PREVIEW: bool = false> {
     resolved_target: ResolvedTarget,
     tls_provider: Option<TlsServerParameterProvider>,
     should_upgrade: bool,
-    ignore_missing_tls_close_notify: bool,
+    options: StreamOptions<PREVIEW>,
 }
 
-impl Acceptor {
+#[derive(Debug, Clone, Copy)]
+struct StreamOptions<const PREVIEW: bool> {
+    ignore_missing_tls_close_notify: bool,
+    preview_configuration: Option<PreviewConfiguration>,
+    tcp_backlog: Option<u32>,
+    tls_backlog: Option<u32>,
+}
+
+impl<const PREVIEW: bool> Default for StreamOptions<PREVIEW> {
+    fn default() -> Self {
+        Self {
+            ignore_missing_tls_close_notify: false,
+            preview_configuration: None,
+            tcp_backlog: None,
+            tls_backlog: None,
+        }
+    }
+}
+
+impl Acceptor<false> {
     pub fn new(target: ResolvedTarget) -> Self {
         Self {
             resolved_target: target,
             tls_provider: None,
             should_upgrade: false,
-            ignore_missing_tls_close_notify: false,
+            options: Default::default(),
         }
     }
 
@@ -35,7 +55,7 @@ impl Acceptor {
             resolved_target: target,
             tls_provider: Some(provider),
             should_upgrade: true,
-            ignore_missing_tls_close_notify: false,
+            options: Default::default(),
         }
     }
 
@@ -44,7 +64,7 @@ impl Acceptor {
             resolved_target: target,
             tls_provider: Some(provider),
             should_upgrade: false,
-            ignore_missing_tls_close_notify: false,
+            options: Default::default(),
         }
     }
 
@@ -53,7 +73,7 @@ impl Acceptor {
             resolved_target: ResolvedTarget::SocketAddr(addr),
             tls_provider: None,
             should_upgrade: false,
-            ignore_missing_tls_close_notify: false,
+            options: Default::default(),
         }
     }
 
@@ -62,7 +82,7 @@ impl Acceptor {
             resolved_target: ResolvedTarget::SocketAddr(addr),
             tls_provider: Some(provider),
             should_upgrade: true,
-            ignore_missing_tls_close_notify: false,
+            options: Default::default(),
         }
     }
 
@@ -71,7 +91,7 @@ impl Acceptor {
             resolved_target: ResolvedTarget::SocketAddr(addr),
             tls_provider: Some(provider),
             should_upgrade: false,
-            ignore_missing_tls_close_notify: false,
+            options: Default::default(),
         }
     }
 
@@ -84,7 +104,7 @@ impl Acceptor {
                 ),
                 tls_provider: None,
                 should_upgrade: false,
-                ignore_missing_tls_close_notify: false,
+                options: Default::default(),
             })
         }
         #[cfg(not(unix))]
@@ -106,7 +126,7 @@ impl Acceptor {
                 ),
                 tls_provider: None,
                 should_upgrade: false,
-                ignore_missing_tls_close_notify: false,
+                options: Default::default(),
             })
         }
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -124,13 +144,19 @@ impl Acceptor {
         impl ::futures::Stream<Item = Result<Connection, ConnectionError>> + LocalAddress,
         ConnectionError,
     > {
-        let stream = self.resolved_target.listen_raw().await?;
-        Ok(AcceptedStream {
+        let stream = self
+            .resolved_target
+            .listen_raw(self.options.tcp_backlog)
+            .await?;
+        Ok(AcceptedStream::<Connection<Ssl>> {
             stream,
             should_upgrade: self.should_upgrade,
-            ignore_missing_tls_close_notify: self.ignore_missing_tls_close_notify,
-            upgrade_future: None,
+            ignore_missing_tls_close_notify: self.options.ignore_missing_tls_close_notify,
             tls_provider: self.tls_provider,
+            tls_backlog: TlsAcceptBacklog::new(
+                self.options.tls_backlog.unwrap_or(DEFAULT_TLS_BACKLOG) as _,
+            ),
+            preview_configuration: None,
             _phantom: None,
         })
     }
@@ -142,98 +168,332 @@ impl Acceptor {
         impl ::futures::Stream<Item = Result<Connection<D>, ConnectionError>> + LocalAddress,
         ConnectionError,
     > {
-        let stream = self.resolved_target.listen_raw().await?;
-        Ok(AcceptedStream {
+        let stream = self
+            .resolved_target
+            .listen_raw(self.options.tcp_backlog)
+            .await?;
+        Ok(AcceptedStream::<Connection<D>, D> {
             stream,
-            ignore_missing_tls_close_notify: self.ignore_missing_tls_close_notify,
+            ignore_missing_tls_close_notify: self.options.ignore_missing_tls_close_notify,
             should_upgrade: self.should_upgrade,
-            upgrade_future: None,
             tls_provider: self.tls_provider,
+            tls_backlog: TlsAcceptBacklog::new(
+                self.options.tls_backlog.unwrap_or(DEFAULT_TLS_BACKLOG) as _,
+            ),
+            preview_configuration: None,
             _phantom: None,
         })
     }
 
-    pub async fn accept_one(self) -> Result<Connection, std::io::Error> {
-        let mut stream = self.resolved_target.listen().await?;
-        let (stream, _target) = stream.next().await.unwrap()?;
-        let mut stm = UpgradableStream::new_server(
-            RewindStream::new(stream),
-            None::<TlsServerParameterProvider>,
-        );
-        if self.ignore_missing_tls_close_notify {
-            stm.ignore_missing_close_notify();
-        }
-        Ok(stm)
+    /// Listen, and then accept one and only one connection from the listener.
+    pub async fn accept_one(self) -> Result<Connection, ConnectionError> {
+        let Some(conn) = self.bind().await?.next().await else {
+            return Err(ConnectionError::Io(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "No connection received",
+            )));
+        };
+        conn
     }
 }
 
-struct AcceptedStream<D: TlsDriver = Ssl> {
+impl Acceptor<true> {
+    /// Create a new TCP/TLS acceptor that will preview the first
+    /// [`PreviewConfiguration::max_preview_bytes`] bytes of the connection.
+    pub fn new_tcp_tls_previewing(
+        addr: SocketAddr,
+        preview_configuration: PreviewConfiguration,
+        provider: TlsServerParameterProvider,
+    ) -> Self {
+        Self {
+            resolved_target: ResolvedTarget::SocketAddr(addr),
+            tls_provider: Some(provider),
+            should_upgrade: false,
+            options: StreamOptions {
+                preview_configuration: Some(preview_configuration),
+                ..Default::default()
+            },
+        }
+    }
+
+    pub async fn bind(
+        self,
+    ) -> Result<
+        impl ::futures::Stream<Item = Result<(Preview, Connection), ConnectionError>> + LocalAddress,
+        ConnectionError,
+    > {
+        let stream = self
+            .resolved_target
+            .listen_raw(self.options.tcp_backlog)
+            .await?;
+        Ok(AcceptedStream::<(Preview, Connection<Ssl>)> {
+            stream,
+            should_upgrade: self.should_upgrade,
+            ignore_missing_tls_close_notify: self.options.ignore_missing_tls_close_notify,
+            tls_provider: self.tls_provider,
+            tls_backlog: TlsAcceptBacklog::new(self.options.tls_backlog.unwrap_or(128) as _),
+            preview_configuration: self.options.preview_configuration,
+            _phantom: None,
+        })
+    }
+
+    #[allow(private_bounds)]
+    pub async fn bind_explicit<D: TlsDriver>(
+        self,
+    ) -> Result<
+        impl ::futures::Stream<Item = Result<(Preview, Connection<D>), ConnectionError>> + LocalAddress,
+        ConnectionError,
+    > {
+        let stream = self
+            .resolved_target
+            .listen_raw(self.options.tcp_backlog)
+            .await?;
+        Ok(AcceptedStream::<(Preview, Connection<D>), D> {
+            stream,
+            should_upgrade: self.should_upgrade,
+            ignore_missing_tls_close_notify: self.options.ignore_missing_tls_close_notify,
+            tls_provider: self.tls_provider,
+            tls_backlog: TlsAcceptBacklog::new(
+                self.options.tls_backlog.unwrap_or(DEFAULT_TLS_BACKLOG) as _,
+            ),
+            preview_configuration: self.options.preview_configuration,
+            _phantom: None,
+        })
+    }
+
+    /// Listen, and then accept one and only one connection from the listener.
+    pub async fn accept_one(self) -> Result<(Preview, Connection), ConnectionError> {
+        let Some(conn) = self.bind().await?.next().await else {
+            return Err(ConnectionError::Io(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "No connection received",
+            )));
+        };
+        conn
+    }
+}
+
+struct AcceptedStream<S, D: TlsDriver = Ssl> {
     stream: TokioListenerStream,
     should_upgrade: bool,
     ignore_missing_tls_close_notify: bool,
     tls_provider: Option<TlsServerParameterProvider>,
-    #[allow(clippy::type_complexity)]
-    upgrade_future:
-        Option<Pin<Box<dyn Future<Output = Result<Connection<D>, SslError>> + Send + 'static>>>,
+    tls_backlog: TlsAcceptBacklog<S>,
+    preview_configuration: Option<PreviewConfiguration>,
     // Avoid using PhantomData because it fails to implement certain auto-traits
     _phantom: Option<&'static D>,
 }
 
-impl<D: TlsDriver> LocalAddress for AcceptedStream<D> {
+impl<S, D: TlsDriver> LocalAddress for AcceptedStream<S, D> {
     fn local_address(&self) -> std::io::Result<ResolvedTarget> {
         self.stream.local_address()
     }
 }
 
-impl<D: TlsDriver> futures::Stream for AcceptedStream<D> {
+impl<D: TlsDriver> futures::Stream for AcceptedStream<Connection<D>, D> {
     type Item = Result<Connection<D>, ConnectionError>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        if let Some(mut upgrade_future) = self.upgrade_future.take() {
-            match upgrade_future.poll_unpin(cx) {
-                Poll::Ready(Ok(conn)) => {
-                    return Poll::Ready(Some(Ok(conn)));
-                }
-                Poll::Ready(Err(e)) => {
-                    return Poll::Ready(Some(Err(e.into())));
-                }
-                Poll::Pending => {
-                    self.upgrade_future = Some(upgrade_future);
-                    return Poll::Pending;
-                }
+        let ignore_missing_tls_close_notify = self.ignore_missing_tls_close_notify;
+        let make_stream = move |tls_provider: Option<TlsServerParameterProvider>, stream| {
+            let mut stream = UpgradableStream::<_, D>::new_server(stream, tls_provider);
+            if ignore_missing_tls_close_notify {
+                stream.ignore_missing_close_notify();
             }
-        }
-        let r = ready!(self.stream.poll_next_unpin(cx));
-        let Some(r) = r else {
-            return Poll::Ready(None);
+            stream
         };
-        let (stream, _target) = r?;
-        let mut stream =
-            UpgradableStream::new_server(RewindStream::new(stream), self.tls_provider.clone());
-        if self.ignore_missing_tls_close_notify {
-            stream.ignore_missing_close_notify();
-        }
-        if self.should_upgrade {
-            let mut upgrade_future = Box::pin(async move {
-                stream.secure_upgrade().await?;
-                Ok::<_, SslError>(stream)
+
+        // If we're not upgrading, we can just return the stream as is and skip
+        // the second-level backlog.
+        if !self.should_upgrade {
+            return self.as_mut().stream.poll_next_unpin(cx).map(|c| {
+                c.map(|c| Ok(c.map(|(c, _t)| make_stream(self.tls_provider.clone(), c))?))
             });
-            match upgrade_future.poll_unpin(cx) {
-                Poll::Ready(Ok(stream)) => {
-                    return Poll::Ready(Some(Ok(stream)));
-                }
-                Poll::Ready(Err(e)) => {
-                    return Poll::Ready(Some(Err(e.into())));
-                }
-                Poll::Pending => {
-                    self.upgrade_future = Some(upgrade_future);
+        }
+
+        // Fill the backlog to capacity as log as we have connections to accept.
+        while !self.tls_backlog.is_full() {
+            let Poll::Ready(r) = self.stream.poll_next_unpin(cx) else {
+                if self.tls_backlog.is_empty() {
                     return Poll::Pending;
                 }
-            }
+                break;
+            };
+
+            let Some((stream, _t)) = r.transpose()? else {
+                if self.tls_backlog.is_empty() {
+                    return Poll::Ready(None);
+                }
+                break;
+            };
+
+            let tls_provider = self.tls_provider.clone();
+            self.tls_backlog.push(async move {
+                let mut stream = make_stream(tls_provider, stream);
+                stream.secure_upgrade().await?;
+                Ok(stream)
+            })
         }
-        Poll::Ready(Some(Ok(stream)))
+
+        // We've got at least one pending connection here
+        debug_assert!(!self.tls_backlog.is_empty());
+        let r = ready!(Pin::new(&mut self.tls_backlog).poll_next(cx))?;
+        Poll::Ready(Some(Ok(r)))
+    }
+}
+
+impl<D: TlsDriver> futures::Stream for AcceptedStream<(Preview, Connection<D>), D> {
+    type Item = Result<(Preview, Connection<D>), ConnectionError>;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        // Fill the backlog to capacity as log as we have connections to accept.
+        while !self.tls_backlog.is_full() {
+            let Poll::Ready(r) = self.stream.poll_next_unpin(cx) else {
+                if self.tls_backlog.is_empty() {
+                    return Poll::Pending;
+                }
+                break;
+            };
+
+            let Some((mut stream, _t)) = r.transpose()? else {
+                if self.tls_backlog.is_empty() {
+                    return Poll::Ready(None);
+                }
+                break;
+            };
+
+            let tls_provider = self.tls_provider.clone();
+            let preview_configuration = self.preview_configuration.clone().unwrap();
+            let ignore_missing_tls_close_notify = self.ignore_missing_tls_close_notify;
+            self.tls_backlog.push(async move {
+                let mut buf = smallvec::SmallVec::with_capacity(
+                    preview_configuration.max_preview_bytes.get(),
+                );
+                buf.resize(preview_configuration.max_preview_bytes.get(), 0);
+                stream.read_exact(&mut buf).await?;
+                let mut stream = RewindStream::new(stream);
+                stream.rewind(&buf);
+                let preview = Preview::new(buf);
+                let mut stream = UpgradableStream::<_, D>::new_server_preview(stream, tls_provider);
+                if ignore_missing_tls_close_notify {
+                    stream.ignore_missing_close_notify();
+                }
+
+                Ok((preview, stream))
+            })
+        }
+
+        // We've got at least one pending connection here
+        debug_assert!(!self.tls_backlog.is_empty());
+        let r = ready!(Pin::new(&mut self.tls_backlog).poll_next(cx))?;
+        Poll::Ready(Some(Ok(r)))
+    }
+}
+
+struct TlsAcceptBacklog<C> {
+    capacity: usize,
+    futures: FuturesUnordered<
+        Pin<Box<dyn Future<Output = Result<C, ConnectionError>> + Send + 'static>>,
+    >,
+}
+
+impl<C> TlsAcceptBacklog<C> {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            futures: FuturesUnordered::new(),
+        }
+    }
+
+    fn is_full(&self) -> bool {
+        self.futures.len() >= self.capacity
+    }
+
+    fn is_empty(&self) -> bool {
+        self.futures.len() == 0
+    }
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<C, ConnectionError>> {
+        debug_assert!(!self.is_empty());
+        self.futures.poll_next_unpin(cx).map(|r| r.unwrap())
+    }
+
+    fn push(&mut self, future: impl Future<Output = Result<C, ConnectionError>> + Send + 'static) {
+        self.futures.push(Box::pin(future));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        Connector, OpensslDriver, RustlsDriver, Target, TlsKey, TlsParameters, TlsServerParameters,
+    };
+    use std::net::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn test_acceptor_new_tcp_previewing<D: TlsDriver>() -> Result<(), ConnectionError> {
+        let acceptor = Acceptor::new_tcp_tls_previewing(
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            PreviewConfiguration::default(),
+            TlsServerParameterProvider::new(TlsServerParameters::new_with_certificate(
+                TlsKey::test_key(),
+            )),
+        );
+
+        let mut conns = acceptor.bind().await?;
+
+        let addr = conns.local_address()?;
+        tokio::task::spawn(async move {
+            let mut conn = Connector::new_resolved(addr).connect().await?;
+            conn.write_all(b"HELLO WORLD").await
+        });
+
+        let (preview, mut conn) = conns.next().await.unwrap()?;
+        assert_eq!(preview.len(), 8);
+        assert_eq!(preview, b"HELLO WO");
+        let mut string = String::new();
+        conn.read_to_string(&mut string).await?;
+        assert_eq!(string, "HELLO WORLD");
+
+        let addr = conns.local_address()?;
+        tokio::task::spawn(async move {
+            let target = Target::new_resolved_tls(addr, TlsParameters::insecure());
+            let mut conn = Connector::new(target)?.connect().await?;
+            conn.write_all(b"HELLO WORLD").await
+        });
+
+        let (preview, mut conn) = conns.next().await.unwrap()?;
+        assert_eq!(preview.len(), 8);
+        assert!(matches!(preview.as_ref(), [0x16, 3, 1, ..]));
+        let preview = conn
+            .secure_upgrade_preview(PreviewConfiguration::default())
+            .await?;
+        assert_eq!(preview.len(), 8);
+        assert_eq!(preview, b"HELLO WO");
+
+        let mut string = String::new();
+        conn.read_to_string(&mut string).await?;
+        assert_eq!(string, "HELLO WORLD");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_acceptor_new_tcp_previewing_openssl() -> Result<(), ConnectionError> {
+        test_acceptor_new_tcp_previewing::<OpensslDriver>().await
+    }
+
+    #[tokio::test]
+    async fn test_acceptor_new_tcp_previewing_rustls() -> Result<(), ConnectionError> {
+        test_acceptor_new_tcp_previewing::<RustlsDriver>().await
     }
 }

--- a/gel-stream/src/server/mod.rs
+++ b/gel-stream/src/server/mod.rs
@@ -1,6 +1,2 @@
-use crate::{RewindStream, Ssl, UpgradableStream};
-
 mod acceptor;
 pub use acceptor::Acceptor;
-
-type Connection<D = Ssl> = UpgradableStream<RewindStream<crate::BaseStream>, D>;

--- a/gel-stream/tests/tls.rs
+++ b/gel-stream/tests/tls.rs
@@ -25,7 +25,7 @@ fn load_client_test_ca() -> rustls_pki_types::CertificateDer<'static> {
         .expect("ca cert is bad")
 }
 
-fn load_test_cert() -> rustls_pki_types::CertificateDer<'static> {
+pub(crate) fn load_test_cert() -> rustls_pki_types::CertificateDer<'static> {
     rustls_pemfile::certs(&mut include_str!("../tests/certs/server.cert.pem").as_bytes())
         .next()
         .expect("no cert")
@@ -39,7 +39,7 @@ fn load_test_ca() -> rustls_pki_types::CertificateDer<'static> {
         .expect("ca cert is bad")
 }
 
-fn load_test_key() -> rustls_pki_types::PrivateKeyDer<'static> {
+pub(crate) fn load_test_key() -> rustls_pki_types::PrivateKeyDer<'static> {
     rustls_pemfile::private_key(&mut include_str!("../tests/certs/server.key.pem").as_bytes())
         .expect("no server key")
         .expect("server key is bad")


### PR DESCRIPTION
This implements preview-able streams for server-side OpenSSL and Rustls connections. A preview-able stream allows you to peek at the first N bytes of a stream (8 is the default), to determine which protocol you are about to serve.

This can be used to handle raw or TLS-wrapped protocols of various types and dispatch based on those first N bytes.

The `Acceptor` without previewing is unchanged: it returns a stream of connections. The `Acceptor` with previewing returns a stream of (Preview, Connection) instead, allowing you to peek at the bytes on the connection and potentially call `secure_upgrade` (or `secure_upgrade_preview`) on that connection.

```rust
        let acceptor = Acceptor::new_tcp_tls_previewing(
            SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
            PreviewConfiguration::default(),
            TlsServerParameterProvider::new(TlsServerParameters::new_with_certificate(
                TlsKey::test_key(),
            )),
        );

        let mut conns = acceptor.bind().await?;

        let addr = conns.local_address()?;
        tokio::task::spawn(async move {
            let mut conn = Connector::new_resolved(addr).connect().await?;
            conn.write_all(b"HELLO WORLD").await
        });

        let (preview, mut conn) = conns.next().await.unwrap()?;
        assert_eq!(preview.len(), 8);
        assert_eq!(preview, b"HELLO WO");
```

