### PR TITLE
Improve/refactor gel-stream

### DIFF
--- a/gel-auth/Cargo.toml
+++ b/gel-auth/Cargo.toml
@@ -33,9 +33,9 @@ sha2 = "0.10.8"
 [dev-dependencies]
 gel-pg-captive = { path = "../gel-pg-captive" }
 gel-stream = { path = "../gel-stream", features = ["rustls", "tokio", "client"] }
+gel-auth = { path = ".", features = ["full"] }
 
 tokio = { version = "1", features = ["full"] }
-gel-auth = { path = ".", features = ["full"] }
 pretty_assertions = "1"
 rstest = "0.25"
 hex-literal = "1"

--- a/gel-auth/src/scram/mod.rs
+++ b/gel-auth/src/scram/mod.rs
@@ -550,6 +550,28 @@ pub fn generate_nonce() -> String {
     BASE64_STANDARD.encode(bytes)
 }
 
+/// A stored SCRAM-SHA-256 key.
+///
+/// The SCRAM key format consists of several components separated by '$' and ':'
+/// characters:
+///
+/// `"SCRAM-SHA-256$<iterations>:<salt>$<stored_key>:<server_key>"`
+///
+/// Where:
+///  - `iterations`: Number of PBKDF2-HMAC-SHA256 iterations used for key
+///    derivation
+///  - `salt`: Base64-encoded cryptographically secure random salt used in key
+///    derivation
+///  - `stored_key`: Hash of the client key, where client key is derived as
+///    `SHA-256(HMAC-SHA-256(salted_password, "Client Key"))`
+///  - `server_key`: Server key derived as `HMAC-SHA-256(salted_password,
+///    "Server Key")`
+///
+/// The `stored_key` and `server_key` are pre-computed cryptographic values that
+/// prevent storing the raw password while maintaining secure authentication.
+/// The `stored_key` is a `hash(hmac(P, ...))` used to verify client
+/// authentication proofs, while the `server_key` is a `hmac(P, ...)` used to
+/// generate server authentication signatures.
 #[derive(Clone, Debug)]
 pub struct StoredKey {
     pub iterations: usize,

--- a/gel-pg-captive/Cargo.toml
+++ b/gel-pg-captive/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 gel-auth = { path = "../gel-auth" }
-gel-stream = { path = "../gel-stream", default-features = false }
+gel-stream = { path = "../gel-stream", default-features = false, features = ["__test_keys"] }
 
 tempfile = "3"
 socket2 = { version = "0.5", features = ["all"] }

--- a/gel-stream/Cargo.toml
+++ b/gel-stream/Cargo.toml
@@ -16,13 +16,15 @@ full = ["client", "server", "tokio", "rustls", "openssl", "hickory", "keepalive"
 client = []
 server = []
 serde = ["dep:serde"]
-tokio = ["dep:tokio", "dep:socket2"]
+tokio = ["dep:tokio", "dep:socket2", "dep:derive-io"]
 rustls = ["tokio", "dep:rustls", "dep:rustls-tokio-stream", "dep:rustls-platform-verifier", "dep:webpki", "dep:webpki-roots"]
 openssl = ["tokio", "dep:openssl", "dep:tokio-openssl", "dep:foreign-types", "dep:openssl-sys", "dep:openssl-probe", "dep:webpki-root-certs"]
 hickory = ["dep:hickory-resolver"]
 keepalive = ["dep:socket2"]
 pem = ["dep:rustls-pemfile"]
 __manual_tests = []
+# Provide test certificates, authorities and keys for easier downstream testing
+__test_keys = []
 
 [dependencies]
 derive_more = { version = "2", default-features = false, features = ["debug", "constructor", "from", "try_from", "display", "error"] }
@@ -33,7 +35,7 @@ smallvec = "1"
 # Given that this library may be used in multiple contexts, we want to limit the
 # features we enable by default.
 
-rustls-pki-types = { version = "1", default-features = false, features = ["std"] }
+rustls-pki-types = { version = "1", default-features = false, features = ["std", "alloc"] }
 
 # feature = "keepalive"
 socket2 = { version = "0.5.2", optional = true }
@@ -41,6 +43,7 @@ socket2 = { version = "0.5.2", optional = true }
 # feature = "tokio"
 tokio = { version = "1", optional = true, default-features = false, features = ["net", "rt", "io-util"] }
 hickory-resolver = { version = "0.25.2", optional = true, default-features = false, features = ["tokio", "system-config"] }
+derive-io = { version = "=0.2.2", optional = true }
 
 # feature = "rustls"
 # We rely on certain aspects of these crates. Use caution when upgrading.
@@ -73,7 +76,7 @@ libc = "0.2"
 
 [dev-dependencies]
 # Run tests with all features enabled
-gel-stream = { path = ".", features = ["full"] }
+gel-stream = { path = ".", features = ["full", "__test_keys"] }
 
 tokio = { version = "1", features = ["full"] }
 tempfile = "3"

--- a/gel-stream/README.md
+++ b/gel-stream/README.md
@@ -79,10 +79,9 @@ use futures::TryStreamExt;
 #[tokio::main]
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Create a server that listens on all interfaces on a random port.
-    let tls_params = TlsServerParameters::new_with_certificate(TlsKey::new_pem(
-        include_bytes!("../tests/certs/server.key.pem"),
-        include_bytes!("../tests/certs/server.cert.pem"),
-    )?);
+    let tls_params = TlsServerParameters::new_with_certificate(
+        gel_stream::test_keys::SERVER_KEY.clone_key()
+    );
     let acceptor = Acceptor::new_tcp_tls(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         TlsServerParameterProvider::new(tls_params),

--- a/gel-stream/src/common/target.rs
+++ b/gel-stream/src/common/target.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    hash::{Hash, Hasher},
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::Path,
     sync::Arc,
@@ -510,6 +511,18 @@ pub enum ResolvedTarget {
     UnixSocketAddr(std::os::unix::net::SocketAddr),
 }
 
+/// Because `std::os::unix::net::SocketAddr` does not implement many helper
+/// traits, we temporarily use this enum to represent the inner representation
+/// of the resolved target for easier operation.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum ResolvedTargetInner<'a> {
+    SocketAddr(std::net::SocketAddr),
+    #[cfg(unix)]
+    UnixSocketPath(&'a std::path::Path),
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    UnixSocketAbstract(&'a [u8]),
+}
+
 #[cfg(unix)]
 impl TryFrom<std::path::PathBuf> for ResolvedTarget {
     type Error = std::io::Error;
@@ -525,25 +538,19 @@ impl Eq for ResolvedTarget {}
 
 impl PartialEq for ResolvedTarget {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (ResolvedTarget::SocketAddr(a), ResolvedTarget::SocketAddr(b)) => a == b,
-            #[cfg(unix)]
-            (ResolvedTarget::UnixSocketAddr(a), ResolvedTarget::UnixSocketAddr(b)) => {
-                if let (Some(a), Some(b)) = (a.as_pathname(), b.as_pathname()) {
-                    a == b
-                } else {
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
-                    {
-                        use std::os::linux::net::SocketAddrExt;
-                        if let (Some(a), Some(b)) = (a.as_abstract_name(), b.as_abstract_name()) {
-                            return a == b;
-                        }
-                    }
-                    false
-                }
-            }
-            _ => false,
-        }
+        self.inner() == other.inner()
+    }
+}
+
+impl Hash for ResolvedTarget {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner().hash(state);
+    }
+}
+
+impl PartialOrd for ResolvedTarget {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.inner().partial_cmp(&other.inner())
     }
 }
 
@@ -557,6 +564,29 @@ impl ResolvedTarget {
 
     pub fn is_tcp(&self) -> bool {
         self.tcp().is_some()
+    }
+
+    /// Get the inner representation of the resolved target.
+    #[allow(unreachable_code)]
+    fn inner(&self) -> ResolvedTargetInner {
+        match self {
+            ResolvedTarget::SocketAddr(addr) => ResolvedTargetInner::SocketAddr(*addr),
+            #[cfg(unix)]
+            ResolvedTarget::UnixSocketAddr(addr) => {
+                if let Some(path) = addr.as_pathname() {
+                    return ResolvedTargetInner::UnixSocketPath(path);
+                } else {
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
+                    {
+                        use std::os::linux::net::SocketAddrExt;
+                        return ResolvedTargetInner::UnixSocketAbstract(
+                            addr.as_abstract_name().expect("abstract socket address"),
+                        );
+                    }
+                }
+                unreachable!()
+            }
+        }
     }
 }
 

--- a/gel-stream/src/common/tls.rs
+++ b/gel-stream/src/common/tls.rs
@@ -252,53 +252,11 @@ impl TlsKey {
         Ok(Self { cert, key })
     }
 
-    /// Create a new `TlsKey` from the test certificate and key.
-    #[cfg(test)]
-    pub fn test_key() -> Self {
-        fn load_test_cert() -> rustls_pki_types::CertificateDer<'static> {
-            rustls_pemfile::certs(&mut include_str!("../../tests/certs/server.cert.pem").as_bytes())
-                .next()
-                .expect("no cert")
-                .expect("cert is bad")
-        }
-
-        fn load_test_key() -> rustls_pki_types::PrivateKeyDer<'static> {
-            rustls_pemfile::private_key(
-                &mut include_str!("../../tests/certs/server.key.pem").as_bytes(),
-            )
-            .expect("no server key")
-            .expect("server key is bad")
-        }
-
+    /// Create a clone of this private key and certificate.
+    pub fn clone_key(&self) -> Self {
         Self {
-            key: load_test_key(),
-            cert: load_test_cert(),
-        }
-    }
-
-    /// Create a new `TlsKey` from the test certificate and key.
-    #[cfg(test)]
-    pub fn test_key_alt() -> Self {
-        fn load_test_cert() -> rustls_pki_types::CertificateDer<'static> {
-            rustls_pemfile::certs(
-                &mut include_str!("../../tests/certs/server-alt.cert.pem").as_bytes(),
-            )
-            .next()
-            .expect("no cert")
-            .expect("cert is bad")
-        }
-
-        fn load_test_key() -> rustls_pki_types::PrivateKeyDer<'static> {
-            rustls_pemfile::private_key(
-                &mut include_str!("../../tests/certs/server-alt.key.pem").as_bytes(),
-            )
-            .expect("no server key")
-            .expect("server key is bad")
-        }
-
-        Self {
-            key: load_test_key(),
-            cert: load_test_cert(),
+            key: self.key.clone_key(),
+            cert: self.cert.clone(),
         }
     }
 }

--- a/gel-stream/src/common/tokio_stream.rs
+++ b/gel-stream/src/common/tokio_stream.rs
@@ -2,7 +2,6 @@
 
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
@@ -136,12 +135,21 @@ impl futures::Stream for TokioListenerStream {
 }
 
 /// Represents a connected Tokio stream, either TCP or Unix
+#[derive(derive_io::AsyncRead, derive_io::AsyncWrite)]
 pub enum TokioStream {
     /// TCP stream
-    Tcp(TcpStream),
+    Tcp(
+        #[read]
+        #[write]
+        TcpStream,
+    ),
     /// Unix stream (only available on Unix systems)
     #[cfg(unix)]
-    Unix(UnixStream),
+    Unix(
+        #[read]
+        #[write]
+        UnixStream,
+    ),
 }
 
 impl TokioStream {
@@ -166,79 +174,6 @@ impl TokioStream {
                 std::io::ErrorKind::Unsupported,
                 "Unix sockets do not support keepalive",
             )),
-        }
-    }
-}
-
-impl AsyncRead for TokioStream {
-    #[inline(always)]
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        match self.get_mut() {
-            TokioStream::Tcp(stream) => Pin::new(stream).poll_read(cx, buf),
-            #[cfg(unix)]
-            TokioStream::Unix(stream) => Pin::new(stream).poll_read(cx, buf),
-        }
-    }
-}
-
-impl AsyncWrite for TokioStream {
-    #[inline(always)]
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, std::io::Error>> {
-        match self.get_mut() {
-            TokioStream::Tcp(stream) => Pin::new(stream).poll_write(cx, buf),
-            #[cfg(unix)]
-            TokioStream::Unix(stream) => Pin::new(stream).poll_write(cx, buf),
-        }
-    }
-
-    #[inline(always)]
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
-        match self.get_mut() {
-            TokioStream::Tcp(stream) => Pin::new(stream).poll_flush(cx),
-            #[cfg(unix)]
-            TokioStream::Unix(stream) => Pin::new(stream).poll_flush(cx),
-        }
-    }
-
-    #[inline(always)]
-    fn poll_shutdown(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        match self.get_mut() {
-            TokioStream::Tcp(stream) => Pin::new(stream).poll_shutdown(cx),
-            #[cfg(unix)]
-            TokioStream::Unix(stream) => Pin::new(stream).poll_shutdown(cx),
-        }
-    }
-
-    #[inline(always)]
-    fn is_write_vectored(&self) -> bool {
-        match self {
-            TokioStream::Tcp(stream) => stream.is_write_vectored(),
-            #[cfg(unix)]
-            TokioStream::Unix(stream) => stream.is_write_vectored(),
-        }
-    }
-
-    #[inline(always)]
-    fn poll_write_vectored(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        bufs: &[std::io::IoSlice<'_>],
-    ) -> Poll<Result<usize, std::io::Error>> {
-        match self.get_mut() {
-            TokioStream::Tcp(stream) => Pin::new(stream).poll_write_vectored(cx, bufs),
-            #[cfg(unix)]
-            TokioStream::Unix(stream) => Pin::new(stream).poll_write_vectored(cx, bufs),
         }
     }
 }

--- a/gel-stream/src/server/acceptor.rs
+++ b/gel-stream/src/server/acceptor.rs
@@ -435,7 +435,7 @@ impl<C> TlsAcceptBacklog<C> {
 mod tests {
     use super::*;
     use crate::{
-        Connector, OpensslDriver, RustlsDriver, Target, TlsKey, TlsParameters, TlsServerParameters,
+        Connector, OpensslDriver, RustlsDriver, Target, TlsParameters, TlsServerParameters,
     };
     use std::net::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -445,7 +445,7 @@ mod tests {
             SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
             PreviewConfiguration::default(),
             TlsServerParameterProvider::new(TlsServerParameters::new_with_certificate(
-                TlsKey::test_key(),
+                crate::test_keys::SERVER_KEY.clone_key(),
             )),
         );
 

--- a/gel-stream/tests/tls.rs
+++ b/gel-stream/tests/tls.rs
@@ -7,62 +7,39 @@ use std::net::SocketAddr;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 fn load_client_test_cert() -> rustls_pki_types::CertificateDer<'static> {
-    rustls_pemfile::certs(&mut include_str!("../tests/certs/client.cert.pem").as_bytes())
-        .next()
-        .expect("no cert")
-        .expect("cert is bad")
+    gel_stream::test_keys::binary::CLIENT_CERT.clone()
 }
 
 fn load_client_test_key() -> rustls_pki_types::PrivateKeyDer<'static> {
-    rustls_pemfile::private_key(&mut include_str!("../tests/certs/client.key.pem").as_bytes())
-        .expect("no client key")
-        .expect("client key is bad")
+    gel_stream::test_keys::binary::CLIENT_KEY.clone_key()
 }
 
 fn load_client_test_ca() -> rustls_pki_types::CertificateDer<'static> {
-    rustls_pemfile::certs(&mut include_str!("../tests/certs/client_ca.cert.pem").as_bytes())
-        .next()
-        .expect("no ca cert")
-        .expect("ca cert is bad")
+    gel_stream::test_keys::binary::CLIENT_CA_CERT.clone()
 }
 
 pub(crate) fn load_test_cert() -> rustls_pki_types::CertificateDer<'static> {
-    rustls_pemfile::certs(&mut include_str!("../tests/certs/server.cert.pem").as_bytes())
-        .next()
-        .expect("no cert")
-        .expect("cert is bad")
+    gel_stream::test_keys::binary::SERVER_CERT.clone()
 }
 
 pub(crate) fn load_test_cert_alt() -> rustls_pki_types::CertificateDer<'static> {
-    rustls_pemfile::certs(&mut include_str!("../tests/certs/server-alt.cert.pem").as_bytes())
-        .next()
-        .expect("no cert")
-        .expect("cert is bad")
+    gel_stream::test_keys::binary::SERVER_ALT_CERT.clone()
 }
 
 fn load_test_ca() -> rustls_pki_types::CertificateDer<'static> {
-    rustls_pemfile::certs(&mut include_str!("../tests/certs/ca.cert.pem").as_bytes())
-        .next()
-        .expect("no ca cert")
-        .expect("ca cert is bad")
+    gel_stream::test_keys::binary::CA_CERT.clone()
 }
 
 pub(crate) fn load_test_key() -> rustls_pki_types::PrivateKeyDer<'static> {
-    rustls_pemfile::private_key(&mut include_str!("../tests/certs/server.key.pem").as_bytes())
-        .expect("no server key")
-        .expect("server key is bad")
+    gel_stream::test_keys::binary::SERVER_KEY.clone_key()
 }
 
 fn load_test_key_alt() -> rustls_pki_types::PrivateKeyDer<'static> {
-    rustls_pemfile::private_key(&mut include_str!("../tests/certs/server-alt.key.pem").as_bytes())
-        .expect("no server key")
-        .expect("server key is bad")
+    gel_stream::test_keys::binary::SERVER_ALT_KEY.clone_key()
 }
 
 fn load_test_crls() -> Vec<rustls_pki_types::CertificateRevocationListDer<'static>> {
-    rustls_pemfile::crls(&mut include_str!("../tests/certs/ca.crl.pem").as_bytes())
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap()
+    vec![gel_stream::test_keys::binary::CA_CRL.clone()]
 }
 
 fn tls_server_parameters(


### PR DESCRIPTION
Various small refactorings for frontend work.

 - Use the `derive_io` crate to drastically reduce boilerplate AsyncRead/AsyncWrite delegation
 - `gel-stream` offers a hidden `__test_keys` feature where we can export the test key and cert material for easier testing in other crates
 - Use those test keys in `gel-pg-captive`
 - Add some additional required traits to `ResolvedTarget` + refactor with a new, hidden `ResolvedTargetInner` struct we temporarily create.
 - Migrate some more errors from thiserror to derive_more::Error

