### PR TITLE
gel-stream feature work

### DIFF
--- a/gel-stream/src/common/openssl.rs
+++ b/gel-stream/src/common/openssl.rs
@@ -14,8 +14,8 @@ use std::{
 };
 
 use crate::{
-    LocalAddress, PeekableStream, RemoteAddress, ResolvedTarget, SslError, SslVersion, Stream,
-    StreamMetadata, TlsCert, TlsClientCertVerify, TlsDriver, TlsHandshake, TlsParameters,
+    LocalAddress, PeekableStream, PeerCred, RemoteAddress, ResolvedTarget, SslError, SslVersion,
+    Stream, StreamMetadata, TlsCert, TlsClientCertVerify, TlsDriver, TlsHandshake, TlsParameters,
     TlsServerCertVerify, TlsServerParameterProvider, TlsServerParameters, Transport,
 };
 
@@ -500,6 +500,13 @@ impl PeekableStream for TlsStream {
 impl StreamMetadata for TlsStream {
     fn transport(&self) -> Transport {
         self.0.get_ref().transport()
+    }
+}
+
+impl PeerCred for TlsStream {
+    #[cfg(all(unix, feature = "tokio"))]
+    fn peer_cred(&self) -> std::io::Result<tokio::net::unix::UCred> {
+        self.0.get_ref().peer_cred()
     }
 }
 

--- a/gel-stream/src/common/resolver.rs
+++ b/gel-stream/src/common/resolver.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
-use std::sync::Arc;
 use std::{future::Future, str::FromStr, task::Poll};
 
 use crate::{MaybeResolvedTarget, ResolvedTarget, TargetName, TcpResolve};
@@ -9,7 +8,7 @@ use crate::{MaybeResolvedTarget, ResolvedTarget, TargetName, TcpResolve};
 #[derive(Clone)]
 pub struct Resolver {
     #[cfg(feature = "hickory")]
-    resolver: Arc<hickory_resolver::TokioResolver>,
+    resolver: std::sync::Arc<hickory_resolver::TokioResolver>,
 }
 
 #[cfg(feature = "tokio")]

--- a/gel-stream/src/common/rustls.rs
+++ b/gel-stream/src/common/rustls.rs
@@ -14,9 +14,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadBuf};
 
 use super::tokio_stream::TokioStream;
 use crate::{
-    LocalAddress, RemoteAddress, ResolvedTarget, RewindStream, SslError, SslVersion, Stream,
-    StreamMetadata, TlsClientCertVerify, TlsDriver, TlsHandshake, TlsServerParameterProvider,
-    TlsServerParameters, Transport,
+    LocalAddress, PeerCred, RemoteAddress, ResolvedTarget, RewindStream, SslError, SslVersion,
+    Stream, StreamMetadata, TlsClientCertVerify, TlsDriver, TlsHandshake,
+    TlsServerParameterProvider, TlsServerParameters, Transport,
 };
 use crate::{TlsCert, TlsParameters, TlsServerCertVerify};
 use std::borrow::Cow;
@@ -647,6 +647,16 @@ impl LocalAddress for TlsStream {
 impl RemoteAddress for TlsStream {
     fn remote_address(&self) -> std::io::Result<ResolvedTarget> {
         self.peer_addr().map(|addr| ResolvedTarget::from(addr))
+    }
+}
+
+impl PeerCred for TlsStream {
+    #[cfg(all(unix, feature = "tokio"))]
+    fn peer_cred(&self) -> std::io::Result<tokio::net::unix::UCred> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "TCP streams do not support peer credentials",
+        ))
     }
 }
 

--- a/gel-stream/src/common/tls.rs
+++ b/gel-stream/src/common/tls.rs
@@ -374,7 +374,7 @@ impl TlsAlpn {
         }
     }
 
-    pub fn new_str(alpn: &'static [&'static str]) -> Self {
+    pub fn new_str(alpn: &[&'static str]) -> Self {
         let alpn = alpn
             .iter()
             .map(|s| Cow::Borrowed(s.as_bytes()))

--- a/gel-stream/src/lib.rs
+++ b/gel-stream/src/lib.rs
@@ -102,9 +102,9 @@ pub enum SslError {
     SslIoError(#[from] std::io::Error),
 }
 
-impl Into<std::io::Error> for SslError {
-    fn into(self) -> std::io::Error {
-        match self {
+impl From<SslError> for std::io::Error {
+    fn from(err: SslError) -> Self {
+        match err {
             SslError::SslIoError(e) => e,
             other => std::io::Error::new(std::io::ErrorKind::Other, other),
         }

--- a/gel-stream/src/server/acceptor.rs
+++ b/gel-stream/src/server/acceptor.rs
@@ -216,6 +216,41 @@ impl Acceptor<true> {
         }
     }
 
+    /// Create a new acceptor that will preview the first
+    /// [`PreviewConfiguration::max_preview_bytes`] bytes of the connection.
+    pub fn new_tls_previewing(
+        addr: ResolvedTarget,
+        preview_configuration: PreviewConfiguration,
+        provider: TlsServerParameterProvider,
+    ) -> Self {
+        Self {
+            resolved_target: addr,
+            tls_provider: Some(provider),
+            should_upgrade: false,
+            options: StreamOptions {
+                preview_configuration: Some(preview_configuration),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Create a new acceptor that will preview the first
+    /// [`PreviewConfiguration::max_preview_bytes`] bytes of the connection.
+    pub fn new_previewing(
+        addr: ResolvedTarget,
+        preview_configuration: PreviewConfiguration,
+    ) -> Self {
+        Self {
+            resolved_target: addr,
+            tls_provider: None,
+            should_upgrade: false,
+            options: StreamOptions {
+                preview_configuration: Some(preview_configuration),
+                ..Default::default()
+            },
+        }
+    }
+
     pub async fn bind(
         self,
     ) -> Result<


### PR DESCRIPTION
Implements some necessary features gel-stream for the frontend work:

 - Unix socket peer credentials
 - More options for stream previewing (non-TLS, etc)

