### PR TITLE
Revert changes requiring 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = { version = "0.1" }
 pyo3 = { version = "0.23", features = ["extension-module", "serde", "macros"] }
 
 [workspace.package]
-rust-version = "1.87" # keep in sync with flake.nix
+rust-version = "1.85" # keep in sync with flake.nix
 
 [workspace.lints.clippy]
 useless_format = 'allow'

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           devShells.minimum = pkgs.mkShell {
             buildInputs = [
               (fenix_pkgs.toolchainOf {
-                channel = "1.87"; # keep in sync with ./Cargo.toml rust-version
+                channel = "1.85"; # keep in sync with ./Cargo.toml rust-version
                 sha256 = "sha256-SXRtAuO4IqNOQq+nLbrsDFbVk+3aVA8NNpSZsKlVH/8=";
               }).defaultToolchain
             ] ++ common;

--- a/gel-stream/src/common/stream.rs
+++ b/gel-stream/src/common/stream.rs
@@ -74,6 +74,7 @@ impl<T> Stream for T where
 {
 }
 
+// NOTE: Once we're on Rust 1.87, we can use trait upcasting and get rid of this impl.
 impl PeerCred for Box<dyn Stream + Send> {
     fn peer_cred(&self) -> std::io::Result<tokio::net::unix::UCred> {
         self.as_ref().peer_cred()

--- a/gel-stream/src/common/stream.rs
+++ b/gel-stream/src/common/stream.rs
@@ -76,6 +76,7 @@ impl<T> Stream for T where
 
 // NOTE: Once we're on Rust 1.87, we can use trait upcasting and get rid of this impl.
 impl PeerCred for Box<dyn Stream + Send> {
+    #[cfg(all(unix, feature = "tokio"))]
     fn peer_cred(&self) -> std::io::Result<tokio::net::unix::UCred> {
         self.as_ref().peer_cred()
     }

--- a/gel-stream/src/common/stream.rs
+++ b/gel-stream/src/common/stream.rs
@@ -29,7 +29,7 @@ pub trait AsHandle {
 /// A convenience trait for streams from this crate.
 #[cfg(feature = "tokio")]
 pub trait Stream:
-    tokio::io::AsyncRead + tokio::io::AsyncWrite + StreamMetadata + Unpin + AsHandle + 'static
+    tokio::io::AsyncRead + tokio::io::AsyncWrite + StreamMetadata + Send + Unpin + AsHandle + 'static
 {
     /// Attempt to downcast a generic stream to a specific stream type.
     fn downcast<S: Stream + 'static>(self) -> Result<S, Self>
@@ -47,8 +47,8 @@ pub trait Stream:
         Err(holder.take().unwrap())
     }
 
-    /// Box the stream.
-    fn boxed(self) -> Box<dyn Stream>
+    /// Box the stream as a `Box<dyn Stream + Send>`.
+    fn boxed(self) -> Box<dyn Stream + Send>
     where
         Self: Sized + 'static,
     {
@@ -72,6 +72,30 @@ impl<T> Stream for T where
         + Send
         + 'static
 {
+}
+
+impl PeerCred for Box<dyn Stream + Send> {
+    fn peer_cred(&self) -> std::io::Result<tokio::net::unix::UCred> {
+        self.as_ref().peer_cred()
+    }
+}
+
+impl LocalAddress for Box<dyn Stream + Send> {
+    fn local_address(&self) -> std::io::Result<ResolvedTarget> {
+        self.as_ref().local_address()
+    }
+}
+
+impl RemoteAddress for Box<dyn Stream + Send> {
+    fn remote_address(&self) -> std::io::Result<ResolvedTarget> {
+        self.as_ref().remote_address()
+    }
+}
+
+impl StreamMetadata for Box<dyn Stream + Send> {
+    fn transport(&self) -> Transport {
+        self.as_ref().transport()
+    }
 }
 
 #[cfg(not(feature = "tokio"))]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87"
+channel = "1.85"
 components = ["rustc", "cargo", "rust-std", "rust-src", "clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
We used trait upcasting in a single location requiring a bump to 1.87. Let's avoid the use and stay on 1.85 by manually implementing the trait upcast.
