### PR TITLE
Don't start the test server unless we're running tests

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 anyhow = "1.0.68"
 bytes = "1.0"
-once_cell = "1.17.0"
 dtor = "0"
 env_logger = "0.11"
 thiserror = "2"


### PR DESCRIPTION
The test server was being started, even if no functional tests were being run. To fix this, we only shut it down if something requested it.