### PR TITLE
Port postgres DSN parser example from gel

### DIFF
--- a/gel-dsn/examples/postgres_dsn.rs
+++ b/gel-dsn/examples/postgres_dsn.rs
@@ -1,0 +1,20 @@
+use gel_dsn::{postgres::*, SystemEnvVars};
+
+fn main() {
+    let dsn = std::env::args().nth(1).expect("No DSN provided");
+
+    let mut params = parse_postgres_dsn_env(&dsn, SystemEnvVars).unwrap();
+    #[allow(deprecated)]
+    let home = std::env::home_dir().unwrap();
+    eprintln!("DSN: {dsn}\n----\n{:#?}\n", params);
+    params
+        .password
+        .resolve(Some(&home), &params.hosts, &params.database, &params.user)
+        .unwrap();
+    eprintln!(
+        "Resolved password:\n------------------\n{:#?}\n",
+        params.password
+    );
+    params.ssl.resolve(Some(&home)).unwrap();
+    eprintln!("Resolved SSL:\n-------------\n{:#?}\n", ());
+}

--- a/gel-dsn/src/env.rs
+++ b/gel-dsn/src/env.rs
@@ -36,6 +36,16 @@ impl EnvVar for SystemEnvVars {
     }
 }
 
+impl EnvVar for std::env::Vars {
+    fn read(&self, name: &str) -> Result<Cow<str>, std::env::VarError> {
+        if let Ok(value) = std::env::var(name) {
+            Ok(value.into())
+        } else {
+            Err(std::env::VarError::NotPresent)
+        }
+    }
+}
+
 impl EnvVar for &[(&str, &str)] {
     fn read(&self, name: &str) -> Result<Cow<str>, std::env::VarError> {
         for (key, value) in self.iter() {

--- a/gel-dsn/src/env.rs
+++ b/gel-dsn/src/env.rs
@@ -1,11 +1,12 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
+/// An implementation of `EnvVar` that uses `std::env`.
 pub struct SystemEnvVars;
 
 /// A trait for abstracting the reading of environment variables.
 ///
-/// By default, uses `std::env::Vars` but can be re-implemented for other
+/// By default, uses `SystemEnvVars` but can be re-implemented for other
 /// sources.
 pub trait EnvVar {
     fn default() -> impl EnvVar {
@@ -27,16 +28,6 @@ where
 }
 
 impl EnvVar for SystemEnvVars {
-    fn read(&self, name: &str) -> Result<Cow<str>, std::env::VarError> {
-        if let Ok(value) = std::env::var(name) {
-            Ok(value.into())
-        } else {
-            Err(std::env::VarError::NotPresent)
-        }
-    }
-}
-
-impl EnvVar for std::env::Vars {
     fn read(&self, name: &str) -> Result<Cow<str>, std::env::VarError> {
         if let Ok(value) = std::env::var(name) {
             Ok(value.into())

--- a/gel-dsn/src/lib.rs
+++ b/gel-dsn/src/lib.rs
@@ -7,7 +7,7 @@ mod host;
 pub mod postgres;
 mod user;
 
-pub use env::EnvVar;
+pub use env::{EnvVar, SystemEnvVars};
 pub use file::FileAccess;
 pub use host::{Host, HostType};
 pub use user::UserProfile;


### PR DESCRIPTION
Expose the `SystemEnvVars` from `gel-dsn` and move the sample postgres DSN parser over here.