### PR TITLE
Fix publishing tools with circular dev deps

### DIFF
--- a/gel-pg-captive/Cargo.toml
+++ b/gel-pg-captive/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 gel-auth = { path = "../gel-auth", version = "0.1.5" }
-gel-stream = { path = "../gel-stream", version = "0.4.3", default-features = false, features = ["__test_keys"] }
+gel-stream = { path = "../gel-stream", version = "0.4.3", default-features = false, features = ["client", "tokio", "rustls", "__test_keys"] }
 
 tempfile = "3"
 socket2 = { version = "0.5", features = ["all"] }

--- a/gel-pg-captive/Cargo.toml
+++ b/gel-pg-captive/Cargo.toml
@@ -11,8 +11,8 @@ description = "Run a captive PostgreSQL server for testing purposes."
 workspace = true
 
 [dependencies]
-gel-auth = { path = "../gel-auth" }
-gel-stream = { path = "../gel-stream", default-features = false, features = ["__test_keys"] }
+gel-auth = { path = "../gel-auth", version = "0.1.5" }
+gel-stream = { path = "../gel-stream", version = "0.4.3", default-features = false, features = ["__test_keys"] }
 
 tempfile = "3"
 socket2 = { version = "0.5", features = ["all"] }

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -31,7 +31,7 @@ cd $CRATE_ROOT
 # Compute the crate depedency graph for all gel-* crates from $CRATE
 # This will be a list of crates in publishing order, ending with $CRATE
 
-CRATES=$(cargo tree -p $CRATE --depth 1 --prefix none | grep "gel-" | cut -d ' ' -f 1 | sort | uniq)
+CRATES=$(cargo tree -p $CRATE --depth 1 --prefix none --edges=no-dev | grep "gel-" | cut -d ' ' -f 1 | sort | uniq)
 DEP_GRAPH=$(mktemp)
 
 for CRATE in $CRATES; do


### PR DESCRIPTION
Fix publishing errors for `gel-pg-captive` - we had a circular dev dep w/gel-auth, and the crate needed some versions for its dependencies.