### PR TITLE
Restore accidentally modified error message

### DIFF
--- a/gel-jwt/src/gel.rs
+++ b/gel-jwt/src/gel.rs
@@ -20,10 +20,10 @@ pub enum TokenValidationError {
     #[display("secret key does not authorize access to this instance")]
     #[from(ignore)]
     InvalidInstance(#[error(not(source))] String),
-    #[display("secret key does not authorize access in role {_0}")]
+    #[display("secret key does not authorize access in role {_0:?}")]
     #[from(ignore)]
     InvalidRole(#[error(not(source))] String),
-    #[display("secret key does not authorize access to database {_0}")]
+    #[display("secret key does not authorize access to database {_0:?}")]
     #[from(ignore)]
     InvalidDatabase(#[error(not(source))] String),
 }


### PR DESCRIPTION
The python code checks very specific error messages:

```
                (("roles", ("bad-role",)),):
                    'secret key does not authorize access '
                    + 'in role "admin"',
                (("databases", ("bad-database",)),):
                    'secret key does not authorize access '
                    + 'to database "main"',
```
