### PR TITLE
Fix some gel-jwt deps

### DIFF
--- a/gel-jwt/Cargo.toml
+++ b/gel-jwt/Cargo.toml
@@ -34,7 +34,7 @@ rustls-pki-types = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-jsonwebtoken = { version = "9", default-features = false }
+jsonwebtoken = { version = "9.3", default-features = false }
 ring = { version = "0.17", default-features = false }
 pkcs1 = "0.7.5"
 pkcs8 = "0.10.2"
@@ -48,7 +48,8 @@ der = "0.7.10"
 libc = "0.2"
 elliptic-curve = { version = "0.13.8", features = ["arithmetic"] }
 num-bigint-dig = "0.8.4"
-zeroize = { version = "1", features = ["derive", "serde"] }
+zeroize = { version = "1.8", features = ["derive", "serde"] }
+zeroize_derive = "1.4"
 # Used for into_option()
 subtle = "2.6.1"
 

--- a/gel-jwt/Cargo.toml
+++ b/gel-jwt/Cargo.toml
@@ -25,7 +25,7 @@ uuid = { version = "1", features = ["v4", "serde"], optional = true }
 rand = { version =  "0.8.5", optional = true }
 rsa = { version = "0.9.8", default-features = false, features = ["std"], optional = true }
 
-sha2 = "0.10.8"
+sha2 = "0.10.9"
 base64 = "0.22"
 hmac = "0.12.1"
 derive_more = { version = "2", features = ["error", "debug", "from", "display"] }
@@ -40,19 +40,22 @@ pkcs1 = "0.7.5"
 pkcs8 = "0.10.2"
 sec1 = { version = "0.7.3", features = ["der", "pkcs8", "alloc"] }
 pem = "3"
-const-oid = { version = "0.9.6", features = ["db"] }
+# Keep this here for now
+const-oid = { version = "=0.9.6", features = ["db"] }
 p256 = { version = "0.13.2", features = ["jwk"] }
 base64ct = { version = "1", features = ["alloc"] }
-der = "0.7.9"
+der = "0.7.10"
 libc = "0.2"
 elliptic-curve = { version = "0.13.8", features = ["arithmetic"] }
 num-bigint-dig = "0.8.4"
 zeroize = { version = "1", features = ["derive", "serde"] }
+# Used for into_option()
+subtle = "2.6.1"
 
 [dev-dependencies]
 pretty_assertions = "1"
 rstest = "0.25"
-hex-literal = "0.4.1"
+hex-literal = "1"
 divan = "0.1.17"
 gel-jwt = { path = ".", features = ["gel", "keygen"] }
 


### PR DESCRIPTION
We have a transitive dep that wasn't locked at a high enough version (subtle needs to be 2.6.1 to get access to the "into_option" method)