### PR TITLE
Build minimal version of deps on the default rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
                   task: [check, test-fast]
                 - rust_version: [stable]
                   task: [check, test]
+                - rust_version: [default]
+                  task: [build-minimal]
               macos:
                 rust_version: [stable]
                 task: [check, test]

--- a/gel-db-protocol/Cargo.toml
+++ b/gel-db-protocol/Cargo.toml
@@ -19,4 +19,4 @@ const-str = "0.6"
 
 [dev-dependencies]
 pretty_assertions = "1.2.0"
-static_assertions = "1"
+static_assertions = "1.1"

--- a/gel-protocol/Cargo.toml
+++ b/gel-protocol/Cargo.toml
@@ -22,7 +22,7 @@ uuid = "1.1.2"
 num-bigint = {version="0.4.3", optional=true}
 num-traits = {version="0.2.10", optional=true}
 bigdecimal = {version="0.4.0", optional=true}
-chrono = {version="0.4.23", optional=true, features=["std"], default-features=false}
+chrono = {version="0.4.41", optional=true, features=["std"], default-features=false}
 bitflags = "2.4.0"
 serde = {version="1.0.190", features = ["derive"], optional=true}
 serde_json = {version="1", optional=true}

--- a/justfile
+++ b/justfile
@@ -1,6 +1,10 @@
 _default:
     just --list
 
+build-minimal:
+    # Generate a lockfile with minimal versions and build it
+    cargo +nightly generate-lockfile -Z minimal-versions && cargo build
+
 test:
     # Test all features
     cargo test --workspace --all-features
@@ -23,7 +27,6 @@ test:
     cargo clippy --workspace --all-features --all-targets
 
     cargo fmt --check
-
 
 test-fast:
     cargo fmt

--- a/justfile
+++ b/justfile
@@ -2,8 +2,14 @@ _default:
     just --list
 
 build-minimal:
+    #!/bin/bash
     # Generate a lockfile with minimal versions and build it
     cargo +nightly generate-lockfile -Z minimal-versions && cargo build
+
+    for crate in $(tools/list.sh); do
+        echo "Building $crate..."
+        cargo build -p $crate
+    done
 
 test:
     # Test all features
@@ -44,7 +50,7 @@ check:
 
     # Check all crates in the workspace
     CRATES=`cargo tree --workspace --depth 1 --prefix none | grep "gel-" | cut -d ' ' -f 1 | sort | uniq`
-    for crate in $CRATES; do
+    for crate in $(tools/list.sh); do
         echo "Checking $crate..."
         # TODO: this doesn't currently pass because we've got some crates that fail to check
         cargo check --quiet --package $crate --no-default-features || echo "Failed to check $crate with no default features"

--- a/tools/list.sh
+++ b/tools/list.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e -u -o pipefail
+
+CRATE=${1:-}
+
+# Canonicalize the path to the crate root
+CRATE_ROOT=$(cd $(dirname $0)/.. && pwd)
+
+cd $CRATE_ROOT
+
+if [ -z "$CRATE" ]; then
+    # No crate specified, use --workspace
+    CRATES=$(cargo tree --workspace --depth 1 --prefix none | grep "gel-" | cut -d ' ' -f 1 | sort | uniq)
+else
+    # Specific crate specified, use -p $CRATE
+    CRATES=$(cargo tree -p $CRATE --depth 1 --prefix none | grep "gel-" | cut -d ' ' -f 1 | sort | uniq)
+fi
+
+DEP_GRAPH=$(mktemp)
+trap "rm -f $DEP_GRAPH" EXIT
+
+for CRATE in $CRATES; do
+    for DEP in $(cargo tree -p $CRATE --depth 1 --prefix none --edges=no-dev --all-features | grep "gel-" | cut -d ' ' -f 1 | sort | uniq); do
+        echo "$DEP $CRATE" >> $DEP_GRAPH
+    done
+done
+
+tsort $DEP_GRAPH


### PR DESCRIPTION
To avoid issues where we haven't set the minimum crate versions properly, let's run a minimal version lockfile build test on the default version of Rust. This should catch _most_ issues.