### PR TITLE
Add support for `rename` and `crate_path` attributes in Queryable macro

### DIFF
--- a/gel-derive/src/lib.rs
+++ b/gel-derive/src/lib.rs
@@ -108,11 +108,11 @@ fn derive(item: &syn::Item) -> syn::Result<proc_macro2::TokenStream> {
     };
     let attrs = attrib::ContainerAttrs::from_syn(attrs)?;
     if attrs.json {
-        json::derive(item)
+        json::derive(item, &attrs)
     } else {
         match item {
-            syn::Item::Struct(s) => shape::derive_struct(s),
-            syn::Item::Enum(s) => enums::derive_enum(s),
+            syn::Item::Struct(s) => shape::derive_struct(s, &attrs),
+            syn::Item::Enum(s) => enums::derive_enum(s, &attrs),
             _ => Err(syn::Error::new_spanned(
                 item,
                 "can only derive Queryable for a struct and enum \

--- a/gel-derive/tests/rename.rs
+++ b/gel-derive/tests/rename.rs
@@ -1,0 +1,33 @@
+// In the gel-derive crate we want to extend the `Queryable` macro to support the following.
+// A struct and enum attribute (`ContainerAttr`) called crate_path which customises the crate path for the `gel_protocol`.
+// Currently it is hardcoded to `::gel_protocol` but should support adding custom values like `::gelx::exports::gel_protocol`.
+// The second thing is to add a new field attribute called `rename` which allows renaming the field for both enums and structs.
+// After these changes are made the following should be possible.
+
+use gel_derive::Queryable;
+
+mod custom {
+    pub mod exports {
+        pub mod gel_protocol {
+            pub use ::gel_protocol::*;
+        }
+    }
+}
+
+#[derive(Queryable)]
+#[gel(crate_path = custom::exports::gel_protocol)]
+enum Simple {
+    #[gel(rename = "something")]
+    Something,
+    #[gel(rename = "else")]
+    Else,
+}
+
+#[derive(Queryable)]
+#[gel(crate_path = custom::exports::gel_protocol)]
+struct Another {
+    #[gel(rename = "final")]
+    pub r#final: String,
+    #[gel(rename = "self")]
+    pub self_: i16,
+}


### PR DESCRIPTION
### Description

- Introduced `rename` field attribute for renaming fields in structs and enums.
- Added `crate_path` container attribute to customize the crate path for `gel_protocol`.
- Updated relevant parsing and struct implementations to handle new attributes.
- Modified derive functions to accept `ContainerAttrs` for protocol path resolution.
- Added tests to verify the new functionality for both attributes.

I've been working on [gelx](https://github.com/ifiokjr/gelx) and the changes are needed to make the experience of generating code easier. 

### Example

```rust
use gel_derive::Queryable;

mod custom {
    pub mod exports {
        pub mod gel_protocol {
            pub use ::gel_protocol::*;
        }
    }
}

#[derive(Queryable)]
#[gel(crate_path = custom::exports::gel_protocol)]
enum Simple {
    #[gel(rename = "something")]
    Something,
    #[gel(rename = "else")]
    Else,
}

#[derive(Queryable)]
#[gel(crate_path = custom::exports::gel_protocol)]
struct Another {
    #[gel(rename = "final")]
    pub r#final: String,
    #[gel(rename = "self")]
    pub self_: i16,
}
```

