### PR TITLE
Fix publish error in gel-derive

### DIFF
--- a/gel-derive/src/attrib.rs
+++ b/gel-derive/src/attrib.rs
@@ -1,13 +1,11 @@
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 
-#[derive(Debug)]
 enum FieldAttr {
     Json,
     Rename(syn::LitStr),
 }
 
-#[derive(Debug)]
 enum ContainerAttr {
     Json,
     CratePath(syn::Path),


### PR DESCRIPTION
After landing #495, `gel-derive` was not publishing because of a dependency oddity when compiling the whole workspace vs a single project.

I don't know why the build didn't catch this but `cargo build -p gel-derive` did.