### PR TITLE
Implement server message encoding w/gel-db-protocol

### DIFF
--- a/gel-auth/src/gel/server_state_machine.rs
+++ b/gel-auth/src/gel/server_state_machine.rs
@@ -364,7 +364,7 @@ fn send_error(
     update.server_error(&code);
     update.send(&ErrorResponseBuilder {
         severity: ErrorSeverity::Error as u8,
-        error_code: code as i32,
+        error_code: code as u32,
         message,
         attributes: Array::<_, KeyValue>::default(),
     })

--- a/gel-auth/src/gel/server_state_machine.rs
+++ b/gel-auth/src/gel/server_state_machine.rs
@@ -1,9 +1,11 @@
 use gel_protocol::new_protocol::{prelude::*, TransactionState};
 use gel_protocol::new_protocol::{
-    AuthenticationRequiredSASLMessageBuilder, AuthenticationSASLContinueBuilder,
-    AuthenticationSASLFinalBuilder, AuthenticationSASLInitialResponse, AuthenticationSASLResponse,
-    ClientHandshake, EdbError, EdgeDBBackendBuilder, ErrorResponseBuilder, Message,
-    ParameterStatusBuilder, ReadyForCommandBuilder, ServerHandshakeBuilder, ServerKeyDataBuilder,
+    Annotation, AuthenticationOkBuilder, AuthenticationRequiredSASLMessageBuilder,
+    AuthenticationSASLContinueBuilder, AuthenticationSASLFinalBuilder,
+    AuthenticationSASLInitialResponse, AuthenticationSASLResponse, ClientHandshake, EdbError,
+    EdgeDBBackendBuilder, ErrorResponseBuilder, IntoEdgeDBBackendBuilder, KeyValue, Message,
+    ParameterStatusBuilder, ProtocolExtension, ReadyForCommandBuilder, ServerHandshakeBuilder,
+    ServerKeyDataBuilder,
 };
 
 use crate::handshake::{ServerAuth, ServerAuthDrive, ServerAuthError, ServerAuthResponse};
@@ -32,7 +34,10 @@ pub enum ConnectionDrive<'a> {
 }
 
 pub trait ConnectionStateSend {
-    fn send(&mut self, message: EdgeDBBackendBuilder) -> Result<(), std::io::Error>;
+    fn send<'a, M>(
+        &mut self,
+        message: impl IntoEdgeDBBackendBuilder<'a, M>,
+    ) -> Result<(), std::io::Error>;
     fn auth(
         &mut self,
         user: String,
@@ -49,8 +54,9 @@ pub trait ConnectionStateUpdate: ConnectionStateSend {
     fn server_error(&mut self, error: &EdbError) {}
 }
 
-#[derive(Debug)]
+#[derive(derive_more::Debug)]
 pub enum ConnectionEvent<'a> {
+    #[debug("Send(...)")]
     Send(EdgeDBBackendBuilder<'a>),
     Auth(String, String, String),
     Params,
@@ -61,10 +67,13 @@ pub enum ConnectionEvent<'a> {
 
 impl<F> ConnectionStateSend for F
 where
-    F: FnMut(ConnectionEvent) -> Result<(), std::io::Error>,
+    F: for<'a> FnMut(ConnectionEvent<'a>) -> Result<(), std::io::Error>,
 {
-    fn send(&mut self, message: EdgeDBBackendBuilder) -> Result<(), std::io::Error> {
-        self(ConnectionEvent::Send(message))
+    fn send<'a, M>(
+        &mut self,
+        message: impl IntoEdgeDBBackendBuilder<'a, M>,
+    ) -> Result<(), std::io::Error> {
+        self(ConnectionEvent::Send(message.into_builder()))
     }
 
     fn auth(
@@ -210,14 +219,14 @@ impl ServerStateImpl {
                         let minor_ver = handshake.minor_ver();
                         match (major_ver, minor_ver) {
                             (..=0, _) => {
-                                update.send(EdgeDBBackendBuilder::ServerHandshake(ServerHandshakeBuilder { major_ver: 1, minor_ver: 0, extensions: &[] }))?;
+                                update.send(&ServerHandshakeBuilder { major_ver: 1, minor_ver: 0, extensions: Array::<_, ProtocolExtension>::default() })?;
                             }
                             (1, 1..) => {
                                 // 1.(1+) never existed
                                 return Err(PROTOCOL_VERSION_ERROR);
                             }
                             (2, 1..) | (3.., _) => {
-                                update.send(EdgeDBBackendBuilder::ServerHandshake(ServerHandshakeBuilder { major_ver: 2, minor_ver: 0, extensions: &[] }))?;
+                                update.send(&ServerHandshakeBuilder { major_ver: 2, minor_ver: 0, extensions: Array::<_, ProtocolExtension>::default() })?;
                             }
                             _ => {}
                         }
@@ -252,14 +261,12 @@ impl ServerStateImpl {
                 let mut auth = ServerAuth::new(username.clone(), auth_type, credential_data);
                 match auth.drive(ServerAuthDrive::Initial) {
                     ServerAuthResponse::Initial(AuthType::ScramSha256, _) => {
-                        update.send(EdgeDBBackendBuilder::AuthenticationRequiredSASLMessage(
-                            AuthenticationRequiredSASLMessageBuilder {
-                                methods: &["SCRAM-SHA-256"],
-                            },
-                        ))?;
+                        update.send(&AuthenticationRequiredSASLMessageBuilder {
+                            methods: &["SCRAM-SHA-256"],
+                        })?;
                     }
                     ServerAuthResponse::Complete(..) => {
-                        update.send(EdgeDBBackendBuilder::AuthenticationOk(Default::default()))?;
+                        update.send(&AuthenticationOkBuilder {})?;
                         *self = Synchronizing;
                         update.params()?;
                         return Ok(());
@@ -274,9 +281,9 @@ impl ServerStateImpl {
                     (AuthenticationSASLInitialResponse as sasl) if auth.is_initial_message() => {
                         match auth.drive(ServerAuthDrive::Message(AuthType::ScramSha256, sasl.sasl_data().as_ref())) {
                             ServerAuthResponse::Continue(final_message) => {
-                                update.send(EdgeDBBackendBuilder::AuthenticationSASLContinue(AuthenticationSASLContinueBuilder {
-                                    sasl_data: &final_message,
-                                }))?;
+                                update.send(&AuthenticationSASLContinueBuilder {
+                                    sasl_data: final_message.as_slice(),
+                                })?;
                             }
                             ServerAuthResponse::Error(e) => return Err(e.into()),
                             _ => return Err(PROTOCOL_ERROR),
@@ -285,10 +292,10 @@ impl ServerStateImpl {
                     (AuthenticationSASLResponse as sasl) if !auth.is_initial_message() => {
                         match auth.drive(ServerAuthDrive::Message(AuthType::ScramSha256, sasl.sasl_data().as_ref())) {
                             ServerAuthResponse::Complete(data) => {
-                                update.send(EdgeDBBackendBuilder::AuthenticationSASLFinal(AuthenticationSASLFinalBuilder {
-                                    sasl_data: &data,
-                                }))?;
-                                update.send(EdgeDBBackendBuilder::AuthenticationOk(Default::default()))?;
+                                update.send(&AuthenticationSASLFinalBuilder {
+                                    sasl_data: data.as_slice(),
+                                })?;
+                                update.send(&AuthenticationOkBuilder::default())?;
                                 *self = Synchronizing;
                                 update.params()?;
                             }
@@ -302,23 +309,17 @@ impl ServerStateImpl {
                 });
             }
             (Synchronizing, ConnectionDrive::Parameter(name, value)) => {
-                update.send(EdgeDBBackendBuilder::ParameterStatus(
-                    ParameterStatusBuilder {
-                        name: name.as_bytes(),
-                        value: value.as_bytes(),
-                    },
-                ))?;
+                update.send(&ParameterStatusBuilder {
+                    name: name.as_bytes(),
+                    value: value.as_bytes(),
+                })?;
             }
             (Synchronizing, ConnectionDrive::Ready(key_data)) => {
-                update.send(EdgeDBBackendBuilder::ServerKeyData(ServerKeyDataBuilder {
-                    data: key_data,
-                }))?;
-                update.send(EdgeDBBackendBuilder::ReadyForCommand(
-                    ReadyForCommandBuilder {
-                        annotations: &[],
-                        transaction_state: TransactionState::NotInTransaction,
-                    },
-                ))?;
+                update.send(&ServerKeyDataBuilder { data: key_data })?;
+                update.send(&ReadyForCommandBuilder {
+                    annotations: Array::<_, Annotation>::default(),
+                    transaction_state: TransactionState::NotInTransaction,
+                })?;
                 *self = Ready;
             }
             (_, ConnectionDrive::Fail(error, _)) => {
@@ -361,12 +362,12 @@ fn send_error(
     message: &str,
 ) -> std::io::Result<()> {
     update.server_error(&code);
-    update.send(EdgeDBBackendBuilder::ErrorResponse(ErrorResponseBuilder {
-        severity: ErrorSeverity::Error as _,
+    update.send(&ErrorResponseBuilder {
+        severity: ErrorSeverity::Error as u8,
         error_code: code as i32,
         message,
-        attributes: &[],
-    }))
+        attributes: Array::<_, KeyValue>::default(),
+    })
 }
 
 #[allow(unused)]

--- a/gel-auth/src/postgres/mod.rs
+++ b/gel-auth/src/postgres/mod.rs
@@ -94,6 +94,7 @@ mod tests {
     use super::*;
     use crate::*;
     use gel_pg_protocol::errors::*;
+    use gel_pg_protocol::prelude::*;
     use gel_pg_protocol::protocol::*;
     use rstest::rstest;
     use std::collections::VecDeque;
@@ -125,12 +126,20 @@ mod tests {
     }
 
     impl client::ConnectionStateSend for ConnectionPipe {
-        fn send(&mut self, message: FrontendBuilder) -> Result<(), std::io::Error> {
+        fn send<'a, M>(
+            &mut self,
+            message: impl IntoFrontendBuilder<'a, M>,
+        ) -> Result<(), std::io::Error> {
+            let message = message.into_builder();
             eprintln!("Client -> Server {message:?}");
             self.smsg.push_back((false, message.to_vec()));
             Ok(())
         }
-        fn send_initial(&mut self, message: InitialBuilder) -> Result<(), std::io::Error> {
+        fn send_initial<'a, M>(
+            &mut self,
+            message: impl IntoInitialBuilder<'a, M>,
+        ) -> Result<(), std::io::Error> {
+            let message = message.into_builder();
             eprintln!("Client -> Server {message:?}");
             self.smsg.push_back((true, message.to_vec()));
             Ok(())
@@ -159,7 +168,11 @@ mod tests {
             self.sparams = true;
             Ok(())
         }
-        fn send(&mut self, message: BackendBuilder) -> Result<(), std::io::Error> {
+        fn send<'a, M>(
+            &mut self,
+            message: impl IntoBackendBuilder<'a, M>,
+        ) -> Result<(), std::io::Error> {
+            let message = message.into_builder();
             eprintln!("Server -> Client {message:?}");
             self.cmsg.push_back((false, message.to_vec()));
             Ok(())

--- a/gel-auth/tests/real_postgres.rs
+++ b/gel-auth/tests/real_postgres.rs
@@ -190,7 +190,7 @@ pub async fn connect_raw_ssl(
             }
         }
         if state.read_ssl_response() {
-            let ssl_response = SSLResponse::new(&buffer)?;
+            let ssl_response = SSLResponse::new(&buffer[..n]).unwrap();
             stream = update
                 .drive(
                     &mut state,

--- a/gel-auth/tests/real_postgres.rs
+++ b/gel-auth/tests/real_postgres.rs
@@ -11,7 +11,7 @@ use gel_auth::*;
 use gel_pg_captive::*;
 use gel_pg_protocol::errors::PgServerError;
 use gel_pg_protocol::prelude::StructBuffer;
-use gel_pg_protocol::protocol::{FrontendBuilder, InitialBuilder, Message, SSLResponse};
+use gel_pg_protocol::protocol::{IntoFrontendBuilder, IntoInitialBuilder, Message, SSLResponse};
 use gel_stream::{Connector, RawStream, StreamUpgrade, Target, TlsParameters};
 use rstest::rstest;
 use tokio::io::AsyncWriteExt;
@@ -43,11 +43,19 @@ pub struct ConnectionDriver {
 }
 
 impl ConnectionStateSend for ConnectionDriver {
-    fn send_initial(&mut self, message: InitialBuilder) -> Result<(), std::io::Error> {
+    fn send_initial<'a, M>(
+        &mut self,
+        message: impl IntoInitialBuilder<'a, M>,
+    ) -> Result<(), std::io::Error> {
+        let message = message.into_builder();
         self.send_buffer.extend(message.to_vec());
         Ok(())
     }
-    fn send(&mut self, message: FrontendBuilder) -> Result<(), std::io::Error> {
+    fn send<'a, M>(
+        &mut self,
+        message: impl IntoFrontendBuilder<'a, M>,
+    ) -> Result<(), std::io::Error> {
+        let message = message.into_builder();
         self.send_buffer.extend(message.to_vec());
         Ok(())
     }

--- a/gel-db-protocol/Cargo.toml
+++ b/gel-db-protocol/Cargo.toml
@@ -16,6 +16,7 @@ paste = "1"
 derive_more = { version = "2", features = ["debug", "display", "deref", "deref_mut", "error"] }
 uuid = "1"
 const-str = "0.6"
+type-mapper = "=0.1.2"
 
 [dev-dependencies]
 pretty_assertions = "1.2.0"

--- a/gel-db-protocol/src/buffer.rs
+++ b/gel-db-protocol/src/buffer.rs
@@ -202,7 +202,7 @@ mod tests {
         let mut buffer = StructBuffer::<Message>::default();
         let mut f = |msg: Result<Message, ParseError>| {
             let msg = msg.unwrap();
-            eprintln!("Message: {msg:?}");
+            eprintln!("Message: {msg:?} (buf = {:?})", msg.as_ref());
             accumulated_messages.push(msg.to_vec());
         };
 
@@ -218,9 +218,9 @@ mod tests {
 
         assert_eq!(accumulated_messages.len(), 3);
 
-        let mut out = vec![];
+        let mut out: Vec<u8> = vec![];
         for message in accumulated_messages {
-            out.append(&mut message.to_vec());
+            out.extend(&message);
         }
 
         assert_eq!(&out, buf);

--- a/gel-db-protocol/src/datatypes.rs
+++ b/gel-db-protocol/src/datatypes.rs
@@ -193,6 +193,30 @@ impl<'a> AsRef<Encoded<'a>> for Encoded<'a> {
     }
 }
 
+impl<'a> From<&'a [u8]> for Encoded<'a> {
+    fn from(value: &'a [u8]) -> Self {
+        Encoded::Value(value)
+    }
+}
+
+impl<'a> Into<Option<&'a [u8]>> for Encoded<'a> {
+    fn into(self) -> Option<&'a [u8]> {
+        match self {
+            Encoded::Null => None,
+            Encoded::Value(value) => Some(value),
+        }
+    }
+}
+
+impl<'a, 'b> Into<Option<&'a [u8]>> for &'b Encoded<'a> {
+    fn into(self) -> Option<&'a [u8]> {
+        match self {
+            Encoded::Null => None,
+            Encoded::Value(value) => Some(value),
+        }
+    }
+}
+
 impl Encoded<'_> {}
 
 impl PartialEq<str> for Encoded<'_> {

--- a/gel-db-protocol/src/encoding.rs
+++ b/gel-db-protocol/src/encoding.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 use crate::datatypes::*;
 use crate::declare_type;
 use crate::prelude::*;
@@ -81,6 +83,22 @@ pub trait EncoderForExt {
         let mut writer = BufWriter::new(buf);
         EncoderFor::<F>::encode_for(self, &mut writer);
         writer.finish()
+    }
+
+    /// Encode this builder into a given buffer. If the buffer is
+    /// too small, the function will return the number of bytes
+    /// required to encode the builder.
+    #[allow(unused)]
+    fn encode_buffer_uninit<'a, F: 'static>(
+        &self,
+        buf: &'a mut [MaybeUninit<u8>],
+    ) -> Result<&'a mut [u8], usize>
+    where
+        Self: EncoderFor<F>,
+    {
+        let mut writer = BufWriter::new_uninit(buf);
+        EncoderFor::<F>::encode_for(self, &mut writer);
+        writer.finish_buf()
     }
 
     #[allow(unused)]

--- a/gel-db-protocol/src/encoding.rs
+++ b/gel-db-protocol/src/encoding.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use crate::datatypes::*;
 use crate::declare_type;
 use crate::prelude::*;
@@ -12,13 +10,7 @@ where
     Self: Sized,
 {
     const META: StructFieldMeta;
-    /// Always a reference
-    type BuilderForEncode;
-    type BuilderForStruct<'unused>;
-    type DecodeLifetime<'a>;
 
-    fn decode<'a>(buf: &mut &'a [u8]) -> Result<Self::DecodeLifetime<'a>, ParseError>;
-    fn encode(buf: &mut BufWriter<'_>, value: &Self::BuilderForEncode);
     #[allow(unused)]
     fn encode_usize(buf: &mut BufWriter<'_>, value: usize) {
         unreachable!("encode usize")
@@ -34,14 +26,83 @@ pub trait DataTypeFixedSize {
     const SIZE: usize;
 }
 
-impl<const N: usize, T: DataType> DataTypeFixedSize for [T; N] {
-    const SIZE: usize = std::mem::size_of::<T>() * N;
+/// Marks a type as a builder for a given message.
+pub trait BuilderFor: EncoderFor<Self::Message> + Sized {
+    type Message: 'static;
 }
+
+/// Marks a type as a decoder for itself.
+pub trait DecoderFor<'a, F: 'a>: DataType + 'a {
+    fn decode_for(buf: &mut &'a [u8]) -> Result<F, ParseError>;
+}
+
+/// Marks a type as an encoder for a given type.
+pub trait EncoderFor<F: 'static> {
+    fn encode_for(&self, buf: &mut BufWriter<'_>);
+}
+
+/// Helper trait for encodable objects.
+pub trait EncoderForExt {
+    /// Convert this builder into a vector of bytes. This is generally
+    /// not the most efficient way to perform serialization.
+    #[allow(unused)]
+    fn to_vec<F: 'static>(&self) -> Vec<u8>
+    where
+        Self: EncoderFor<F>,
+    {
+        let mut vec = Vec::with_capacity(256);
+        let mut buf = BufWriter::new(&mut vec);
+        EncoderFor::<F>::encode_for(self, &mut buf);
+        match buf.finish() {
+            Ok(size) => {
+                vec.truncate(size);
+                vec
+            }
+            Err(size) => {
+                vec.resize(size, 0);
+                let mut buf = BufWriter::new(&mut vec);
+                EncoderFor::<F>::encode_for(self, &mut buf);
+                // Will not fail this second time
+                let size = buf.finish().unwrap();
+                vec.truncate(size);
+                vec
+            }
+        }
+    }
+
+    /// Encode this builder into a given buffer. If the buffer is
+    /// too small, the function will return the number of bytes
+    /// required to encode the builder.
+    #[allow(unused)]
+    fn encode_buffer<F: 'static>(&self, buf: &mut [u8]) -> Result<usize, usize>
+    where
+        Self: EncoderFor<F>,
+    {
+        let mut writer = BufWriter::new(buf);
+        EncoderFor::<F>::encode_for(self, &mut writer);
+        writer.finish()
+    }
+
+    #[allow(unused)]
+    fn measure<F: 'static>(&self) -> usize
+    where
+        Self: EncoderFor<F>,
+    {
+        let mut buf = Vec::new();
+        let mut writer = BufWriter::new(&mut buf);
+        EncoderFor::<F>::encode_for(self, &mut writer);
+        writer.finish().unwrap_err()
+    }
+}
+
+impl<T> EncoderForExt for T where T: ?Sized {}
 
 #[derive(derive_more::Error, derive_more::Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParseError {
     #[display("Buffer is too short")]
     TooShort,
+    #[display("Buffer is too long ({_0} extra bytes)")]
+    TooLong(#[error(not(source))] usize),
     #[display("Invalid data for {_0}: {_1}")]
     InvalidData(
         #[error(not(source))] &'static str,
@@ -54,62 +115,125 @@ pub enum ParseError {
     ),
 }
 
-pub struct EncodeTarget<'a> {
-    _phantom: PhantomData<&'a ()>,
-}
-
 impl<'a, L: DataType, T: DataType> DataType for Array<'a, L, T>
 where
-    T::BuilderForEncode: 'a,
-    T::BuilderForStruct<'a>: 'a,
+    T: DecoderFor<'a, T>,
 {
     const META: StructFieldMeta = declare_meta!(
         type = Array,
         constant_size = None,
         flags = [array]
     );
-    type BuilderForEncode = &'a [T::BuilderForEncode];
-    type BuilderForStruct<'unused> = &'a [T::BuilderForStruct<'a>];
-    type DecodeLifetime<'__next_lifetime> =
-        Array<'__next_lifetime, L, T::DecodeLifetime<'__next_lifetime>>;
+}
 
-    fn decode<'__next_lifetime>(
-        buf: &mut &'__next_lifetime [u8],
-    ) -> Result<Self::DecodeLifetime<'__next_lifetime>, ParseError> {
+impl<'a, L: DataType, T: DataType> DecoderFor<'a, Array<'a, L, T>> for Array<'a, L, T>
+where
+    L: 'a,
+    T: DecoderFor<'a, T>,
+{
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
         let len = L::decode_usize(buf)?;
         let orig_buf = *buf;
         for _ in 0..len {
-            T::decode(buf)?;
+            T::decode_for(buf)?;
         }
         Ok(Array::new(orig_buf, len as _))
     }
+}
 
-    fn encode(buf: &mut BufWriter<'_>, value: &Self::BuilderForEncode) {
-        L::encode_usize(buf, value.len());
-        for elem in value.iter() {
-            T::encode(buf, elem);
+impl<L: DataType + 'static, T: DataType + 'static, IT> EncoderFor<Array<'static, L, T>>
+    for &'_ [IT]
+where
+    IT: EncoderFor<T>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let iter = self.into_iter();
+        L::encode_usize(buf, self.len());
+        for elem in iter {
+            IT::encode_for(&elem, buf);
+        }
+    }
+}
+
+impl<L: DataType + 'static, T: DataType + 'static, const N: usize, IT>
+    EncoderFor<Array<'static, L, T>> for [IT; N]
+where
+    IT: EncoderFor<T>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let iter = self.into_iter();
+        L::encode_usize(buf, self.len());
+        for elem in iter {
+            IT::encode_for(&elem, buf);
+        }
+    }
+}
+
+impl<L: DataType + 'static, T: DataType + 'static, const N: usize, IT>
+    EncoderFor<Array<'static, L, T>> for &'_ [IT; N]
+where
+    IT: EncoderFor<T>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let iter = self.into_iter();
+        L::encode_usize(buf, self.len());
+        for elem in iter {
+            IT::encode_for(&elem, buf);
+        }
+    }
+}
+
+impl<'a, L, T, U> EncoderFor<Array<'static, L, T>> for Array<'a, L, U>
+where
+    L: DataType + 'static,
+    U: EncoderFor<T> + DecoderFor<'a, U>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        L::encode_usize(buf, self.len());
+        for elem in self.into_iter() {
+            U::encode_for(&elem, buf);
+        }
+    }
+}
+
+impl<L: DataType + 'static, T: DataType + 'static, F, I, II, IT> EncoderFor<Array<'static, L, T>>
+    for F
+where
+    F: Fn() -> I,
+    I: IntoIterator<Item = IT, IntoIter = II>,
+    IT: EncoderFor<T>,
+    II: ExactSizeIterator<Item = IT>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let iter = self().into_iter();
+        L::encode_usize(buf, II::len(&iter));
+        for elem in iter {
+            IT::encode_for(&elem, buf);
         }
     }
 }
 
 impl<'a, T: DataType> DataType for ZTArray<'a, T>
 where
-    T::BuilderForEncode: 'a,
-    T::BuilderForStruct<'a>: 'a,
+    T: DecoderFor<'a, T>,
 {
     const META: StructFieldMeta = declare_meta!(
         type = ZTArray,
         constant_size = None,
         flags = [array]
     );
-    type BuilderForEncode = &'a [T::BuilderForEncode];
-    type BuilderForStruct<'unused> = &'a [T::BuilderForStruct<'a>];
-    type DecodeLifetime<'__next_lifetime> =
-        ZTArray<'__next_lifetime, T::DecodeLifetime<'__next_lifetime>>;
+}
 
-    fn decode<'__next_lifetime>(
-        buf: &mut &'__next_lifetime [u8],
-    ) -> Result<Self::DecodeLifetime<'__next_lifetime>, ParseError> {
+impl<'a, T: DataType> DecoderFor<'a, ZTArray<'a, T>> for ZTArray<'a, T>
+where
+    T: DecoderFor<'a, T>,
+{
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
         let mut orig_buf = *buf;
         let mut len = 0;
         loop {
@@ -121,15 +245,82 @@ where
                 *buf = &buf[1..];
                 break;
             }
-            T::decode(buf)?;
+            T::decode_for(buf)?;
             len += 1;
         }
         Ok(ZTArray::new(orig_buf, len))
     }
+}
 
-    fn encode(buf: &mut BufWriter<'_>, value: &Self::BuilderForEncode) {
-        for elem in value.iter() {
-            T::encode(buf, elem);
+impl<T: DataType + 'static, IT> EncoderFor<ZTArray<'static, T>> for &'_ [IT]
+where
+    IT: EncoderFor<T>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let iter = self.into_iter();
+        for elem in iter {
+            IT::encode_for(&elem, buf);
+        }
+        buf.write(&[0]);
+    }
+}
+
+impl<T: DataType + 'static, const N: usize, IT> EncoderFor<ZTArray<'static, T>> for [IT; N]
+where
+    IT: EncoderFor<T>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let iter = self.into_iter();
+        for elem in iter {
+            IT::encode_for(&elem, buf);
+        }
+        buf.write(&[0]);
+    }
+}
+
+impl<T: DataType + 'static, const N: usize, IT> EncoderFor<ZTArray<'static, T>> for &'_ [IT; N]
+where
+    IT: EncoderFor<T>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let iter = self.into_iter();
+        for elem in iter {
+            IT::encode_for(&elem, buf);
+        }
+        buf.write(&[0]);
+    }
+}
+
+impl<'a, T, U> EncoderFor<ZTArray<'static, T>> for ZTArray<'a, U>
+where
+    T: DataType + 'static,
+    T: DecoderFor<'static, T>,
+    U: DataType,
+    U: EncoderFor<T>,
+    U: DecoderFor<'a, U>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        for elem in self.into_iter() {
+            U::encode_for(&elem, buf);
+        }
+    }
+}
+
+impl<T: DataType + 'static, F, I, II, IT> EncoderFor<ZTArray<'static, T>> for F
+where
+    F: Fn() -> I,
+    I: IntoIterator<Item = IT, IntoIter = II>,
+    IT: EncoderFor<T>,
+    II: Iterator<Item = IT>,
+    T: DecoderFor<'static, T>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let iter = self().into_iter();
+        for elem in iter {
+            IT::encode_for(&elem, buf);
         }
         buf.write(&[0]);
     }
@@ -137,69 +328,173 @@ where
 
 impl<const N: usize, T: DataType> DataType for [T; N]
 where
-    for<'a> T::DecodeLifetime<'a>: Default + Copy,
+    for<'a> T: Default + Copy,
 {
     const META: StructFieldMeta = declare_meta!(
         type = FixedArray,
         constant_size = Some(std::mem::size_of::<T>() * N),
         flags = [array]
     );
-    type BuilderForStruct<'unused> = [T::BuilderForStruct<'unused>; N];
-    type BuilderForEncode = [T::BuilderForEncode; N];
-    type DecodeLifetime<'__next_lifetime> = [T::DecodeLifetime<'__next_lifetime>; N];
-    fn decode<'__next_lifetime>(
-        buf: &mut &'__next_lifetime [u8],
-    ) -> Result<Self::DecodeLifetime<'__next_lifetime>, crate::prelude::ParseError> {
-        let mut res = [T::DecodeLifetime::<'__next_lifetime>::default(); N];
+}
+
+impl<'a, T: DataType, const N: usize> DecoderFor<'a, [T; N]> for [T; N]
+where
+    T: DecoderFor<'a, T> + Default + Copy,
+{
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+        let mut res = [T::default(); N];
         for res in res.iter_mut().take(N) {
-            *res = T::decode(buf)?;
+            *res = T::decode_for(buf)?;
         }
         Ok(res)
     }
-    fn encode(buf: &mut crate::prelude::BufWriter<'_>, value: &Self::BuilderForEncode) {
-        for elem in value {
-            T::encode(buf, elem);
+}
+
+impl<const N: usize, T: DataType> DataTypeFixedSize for [T; N] {
+    const SIZE: usize = std::mem::size_of::<T>() * N;
+}
+
+impl<const N: usize, T: DataType + 'static, U: EncoderFor<T>> EncoderFor<[T; N]> for [U; N] {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        for elem in self {
+            U::encode_for(elem, buf);
         }
     }
 }
 
+/// Implements [`DataType`] and [`DataTypeFixedSize`] for tuples.
+macro_rules! tuple_type {
+    () => {};
+    ($head:ident $(, $tail:ident)*) => {
+        impl <$head: DataType, $($tail: DataType),*> DataType for ($head, $($tail),*) {
+            const META: StructFieldMeta = declare_meta!(type = Tuple, constant_size = None, flags = []);
+        }
+
+        impl <$head: DataType, $($tail: DataType),*> DataTypeFixedSize for ($head, $($tail),*) where $head: DataTypeFixedSize, $($tail: DataTypeFixedSize),* {
+            const SIZE: usize = $head::SIZE $(+ $tail::SIZE)*;
+        }
+
+        $crate::paste!(
+            /// Homomorphic mapping: If A: DecoderFor<A_X>, B: DecoderFor<B_X>, then (A, B): DecoderFor<(A_X, B_X)>
+            impl <'a,$head: DataType, $($tail: DataType),*> DecoderFor<'a, ($head, $($tail),*)> for ($head, $($tail),*) where $head: DecoderFor<'a, $head>, $($tail: DecoderFor<'a, $tail>),* {
+                fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+                    Ok((
+                        $head::decode_for(buf)?,
+                        $($tail::decode_for(buf)?),*
+                    ))
+                }
+            }
+
+            /// Homomorphic mapping: If A: EncoderFor<A_X>, B: EncoderFor<B_X>, then (A, B): EncoderFor<(A_X, B_X)>
+            impl <$head, [<$head X>]: 'static, $($tail, [<$tail X>]: 'static),*>
+                EncoderFor<([<$head X>], $([<$tail X>]),*)> for ($head, $($tail),*)
+
+                where $head: EncoderFor<[<$head X>]>, $($tail: EncoderFor<[<$tail X>]>),* {
+
+                fn encode_for(&self, buf: &mut BufWriter<'_>) {
+                    #[allow(non_snake_case)]
+                    let ($head, $($tail),*) = self;
+                    EncoderFor::<[<$head X>]>::encode_for($head, buf);
+                    $(
+                        EncoderFor::<[<$tail X>]>::encode_for($tail, buf);
+                    )*
+                }
+            }
+        );
+
+        // recurse
+        tuple_type!($($tail),*);
+    };
+}
+
+// Up to 52 fields seems reasonable.
+tuple_type!(
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A1, B1, C1, D1,
+    E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1, P1, Q1, R1, S1, T1, U1, V1, W1, X1, Y1, Z1
+);
+
 declare_type!(DataType, Rest<'a>, builder: &'a [u8],
-{
-    fn decode(buf: &mut &[u8]) -> Result<Self, ParseError> {
+{}
+);
+
+impl<'a> DecoderFor<'a, Rest<'a>> for Rest<'a> {
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
         let res = Rest::new(buf);
         *buf = &[];
         Ok(res)
     }
+}
 
-    fn encode(buf: &mut BufWriter, value: &[u8]) {
-        buf.write(value)
+impl<T> EncoderFor<Rest<'static>> for T
+where
+    T: AsRef<[u8]>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        buf.write(self.as_ref());
     }
 }
-);
 
-declare_type!(DataType, LString<'a>, builder: &'a str, {
-    fn decode(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        let arr = Array::<u32, u8>::decode(buf)?;
+declare_type!(DataType, LString<'a>, builder: &'a str, {});
+
+impl<'a> DecoderFor<'a, LString<'a>> for LString<'a> {
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+        let arr = Array::<u32, u8>::decode_for(buf)?;
         Ok(LString::new(arr.into_slice()))
     }
-    fn encode(buf: &mut BufWriter, value: &str) {
-        Array::<u32, u8>::encode(buf, &value.as_bytes());
+}
+
+impl<T> EncoderFor<LString<'static>> for T
+where
+    for<'any> &'any T: AsRef<str>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let bytes = self.as_ref().as_bytes();
+        EncoderFor::<u32>::encode_for(&(bytes.len() as u32), buf);
+        buf.write(self.as_ref().as_bytes());
     }
-});
+}
+
+impl<'a> EncoderFor<LString<'static>> for LString<'a> {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let bytes = self.to_bytes();
+        EncoderFor::<u32>::encode_for(&(bytes.len() as u32), buf);
+        buf.write(bytes);
+    }
+}
+
 declare_type!(DataType, ZTString<'a>, builder: &'a str, {
-    fn decode(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        let arr = ZTArray::<u8>::decode(buf)?;
+});
+
+impl<'a> DecoderFor<'a, ZTString<'a>> for ZTString<'a> {
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+        let arr = ZTArray::<u8>::decode_for(buf)?;
         let slice = arr.into_slice();
         Ok(ZTString::new(&slice[0..slice.len() - 1]))
     }
-    fn encode(buf: &mut BufWriter, value: &str) {
-        ZTArray::<u8>::encode(buf, &value.as_bytes());
-    }
-});
+}
 
-declare_type!(DataType, Encoded<'a>, builder: Encoded<'a>, {
-    fn decode(buf: &mut &[u8]) -> Result<Self, ParseError> {
-        if let Some((len, array)) = buf.split_first_chunk::<{std::mem::size_of::<i32>()}>() {
+impl<T> EncoderFor<ZTString<'static>> for T
+where
+    for<'any> &'any T: AsRef<str>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        buf.write(self.as_ref().as_bytes());
+        buf.write(&[0]);
+    }
+}
+
+impl<'a> EncoderFor<ZTString<'static>> for ZTString<'a> {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        buf.write(self.to_bytes());
+        buf.write(&[0]);
+    }
+}
+
+declare_type!(DataType, Encoded<'a>, builder: Encoded<'a>, {});
+
+impl<'a> DecoderFor<'a, Encoded<'a>> for Encoded<'a> {
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+        if let Some((len, array)) = buf.split_first_chunk::<{ std::mem::size_of::<i32>() }>() {
             let len = i32::from_be_bytes(*len);
             if len == -1 {
                 *buf = array;
@@ -216,8 +511,23 @@ declare_type!(DataType, Encoded<'a>, builder: Encoded<'a>, {
             Err(ParseError::TooShort)
         }
     }
-    fn encode(buf: &mut BufWriter, value: &Encoded<'a>) {
-        match value {
+}
+
+impl<T> EncoderFor<Encoded<'static>> for Option<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        match self {
+            Some(value) => buf.write(value.as_ref()),
+            None => buf.write(&(-1_i32).to_be_bytes()),
+        }
+    }
+}
+
+impl EncoderFor<Encoded<'static>> for Encoded<'_> {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        match self {
             Encoded::Null => buf.write(&(-1_i32).to_be_bytes()),
             Encoded::Value(value) => {
                 let len: i32 = value.len() as _;
@@ -226,15 +536,22 @@ declare_type!(DataType, Encoded<'a>, builder: Encoded<'a>, {
             }
         }
     }
-});
+}
+
+impl EncoderFor<Encoded<'static>> for &'_ Encoded<'_> {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        match self {
+            Encoded::Null => buf.write(&(-1_i32).to_be_bytes()),
+            Encoded::Value(value) => {
+                let len: i32 = value.len() as _;
+                buf.write(&len.to_be_bytes());
+                buf.write(value);
+            }
+        }
+    }
+}
 
 declare_type!(DataType, Length, flags = [length], {
-    fn decode(buf: [u8; 4]) -> Result<Self, ParseError> {
-        Ok(Self(i32::from_be_bytes(buf)))
-    }
-    fn encode(value: u32) -> [u8; 4] {
-        value.0.to_be_bytes()
-    }
     fn to_usize(value: usize) -> Length {
         Length(value as _)
     }
@@ -243,14 +560,43 @@ declare_type!(DataType, Length, flags = [length], {
     }
 });
 
-declare_type!(DataType, Uuid, {
-    fn decode(buf: [u8; 16]) -> Result<Self, ParseError> {
-        Ok(Uuid::from_bytes(buf))
+impl<'a> DecoderFor<'a, Length> for Length {
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+        i32::decode_for(buf).map(Length)
     }
-    fn encode(value: Uuid) -> [u8; 16] {
-        value.into_bytes()
+}
+
+impl EncoderFor<Length> for u32 {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        buf.write(&self.to_be_bytes());
     }
-});
+}
+
+impl EncoderFor<Length> for Length {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        buf.write(&self.0.to_be_bytes());
+    }
+}
+
+declare_type!(DataType, Uuid, {});
+
+impl<'a> DecoderFor<'a, Uuid> for Uuid {
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+        <[u8; 16] as DecoderFor<'a, [u8; 16]>>::decode_for(buf).map(Uuid::from_bytes)
+    }
+}
+
+impl EncoderFor<Uuid> for &'_ Uuid {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        buf.write(&self.into_bytes());
+    }
+}
+
+impl EncoderFor<Uuid> for Uuid {
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        buf.write(&self.into_bytes());
+    }
+}
 
 declare_type!(u8);
 declare_type!(u16);
@@ -263,3 +609,16 @@ declare_type!(i64);
 
 declare_type!(f32);
 declare_type!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static_assertions::assert_impl_all!(u8: DataType, DataTypeFixedSize);
+    static_assertions::assert_impl_all!([u8; 4]: DataType, DataTypeFixedSize, DecoderFor<'static, [u8; 4]>);
+    static_assertions::assert_impl_all!((u8, u8): DataType, DataTypeFixedSize, EncoderFor<(u8, u8)>);
+
+    static_assertions::assert_impl_all!(&'static str: EncoderFor<LString<'static>>);
+    static_assertions::assert_impl_all!(String: EncoderFor<LString<'static>>);
+    static_assertions::assert_impl_all!(&'static String: EncoderFor<LString<'static>>);
+}

--- a/gel-db-protocol/src/lib.rs
+++ b/gel-db-protocol/src/lib.rs
@@ -24,11 +24,16 @@ pub use message_group::{match_message, message_group};
 /// Re-export for the `protocol!` macro.
 #[doc(hidden)]
 pub use paste::paste;
+#[doc(hidden)]
+pub use type_mapper;
 
 pub mod prelude {
+    pub use super::encoding::BuilderFor;
     pub use super::encoding::DataType;
     pub use super::encoding::DataTypeFixedSize;
-    pub use super::encoding::EncodeTarget;
+    pub use super::encoding::DecoderFor;
+    pub use super::encoding::EncoderFor;
+    pub use super::encoding::EncoderForExt;
     pub use super::encoding::ParseError;
     pub use super::writer::BufWriter;
 

--- a/gel-db-protocol/src/structs.rs
+++ b/gel-db-protocol/src/structs.rs
@@ -209,6 +209,9 @@ impl StructFields {
             if let Some(value) = self.fields[i].field.value {
                 if let Some(fixed_offset) = self.fields[i].fixed_offset {
                     if let Some(constant_size) = self.fields[i].field.meta.constant_size {
+                        if buf.len() < fixed_offset {
+                            return false;
+                        }
                         let buf = buf.split_at(fixed_offset).1;
                         if buf.len() < constant_size {
                             return false;
@@ -274,9 +277,10 @@ impl<T: StructAttributeHasLengthField<true> + StructMeta> StructLength for T {
         if buf.len() < index + std::mem::size_of::<u32>() {
             None
         } else {
-            let len =
-                <u32 as DataType>::decode(&mut &buf[index..index + std::mem::size_of::<u32>()])
-                    .ok()?;
+            let len = <u32 as DecoderFor<'_, u32>>::decode_for(
+                &mut &buf[index..index + std::mem::size_of::<u32>()],
+            )
+            .ok()?;
             Some(index + len as usize)
         }
     }

--- a/gel-frontend/examples/listener.rs
+++ b/gel-frontend/examples/listener.rs
@@ -9,7 +9,7 @@ use gel_frontend::config::TestListenerConfig;
 use gel_frontend::listener::BoundServer;
 use gel_frontend::service::{AuthTarget, BabelfishService, ConnectionIdentity, StreamLanguage};
 use gel_frontend::stream::ListenerStream;
-use gel_pg_protocol::prelude::{StructBuffer, match_message};
+use gel_pg_protocol::prelude::*;
 use gel_protocol::model::Uuid;
 use hyper::Response;
 use tokio::io::ReadBuf;
@@ -53,7 +53,7 @@ impl BabelfishService for ExampleService {
             match language {
                 StreamLanguage::EdgeDB => {
                     use gel_protocol::new_protocol::{
-                        CommandDataDescriptionBuilder, Execute, Message, Parse,
+                        Annotation, CommandDataDescriptionBuilder, Execute, Message, Parse,
                         ReadyForCommandBuilder, Sync, TransactionState,
                     };
                     let mut buffer = StructBuffer::<Message>::default();
@@ -81,19 +81,19 @@ impl BabelfishService for ExampleService {
                                 (Parse as msg) => {
                                     eprintln!("{msg:?}");
                                     send_queue.extend(CommandDataDescriptionBuilder {
-                                        annotations: &[],
+                                        annotations: Array::<_, Annotation>::empty(),
                                         capabilities: 0,
                                         result_cardinality: msg.expected_cardinality(),
                                         input_typedesc_id: Uuid::default(),
-                                        input_typedesc: &[],
+                                        input_typedesc: Array::<_, u8>::empty(),
                                         output_typedesc_id: Uuid::default(),
-                                        output_typedesc: &[]
+                                        output_typedesc: Array::<_, u8>::empty()
                                     }.to_vec());
                                 },
                                 (Sync as msg) => {
                                     eprintln!("{msg:?}");
                                     send_queue.extend(ReadyForCommandBuilder {
-                                        annotations: &[],
+                                        annotations: Array::<_, Annotation>::empty(),
                                         transaction_state: TransactionState::NotInTransaction,
                                     }.to_vec());
                                 },

--- a/gel-frontend/src/listener/mod.rs
+++ b/gel-frontend/src/listener/mod.rs
@@ -559,7 +559,9 @@ mod tests {
     #[timeout(10_000)]
 
     fn test_raw_postgres() {
+        use gel_pg_protocol::prelude::*;
         use gel_pg_protocol::protocol::{StartupMessageBuilder, StartupNameValueBuilder};
+
         run_test_service(TestMode::Tcp, |mut stm| async move {
             let msg = StartupMessageBuilder {
                 params: &[

--- a/gel-frontend/src/listener/postgres.rs
+++ b/gel-frontend/src/listener/postgres.rs
@@ -88,7 +88,10 @@ pub async fn handle_stream_postgres_initial(
             Params => params_ready.store(true, Ordering::SeqCst),
             Send(bytes) => {
                 // TODO: Reduce copies and allocations here
-                send_buf.lock().unwrap().extend_from_slice(&bytes.to_vec());
+                send_buf
+                    .lock()
+                    .unwrap()
+                    .extend_from_slice(bytes.to_vec().as_ref());
             }
             SendSSL(..) => unreachable!(),
             ServerError(e) => {

--- a/gel-pg-protocol/src/protocol.rs
+++ b/gel-pg-protocol/src/protocol.rs
@@ -1017,11 +1017,21 @@ mod tests {
             fields: &[
                 RowFieldBuilder {
                     name: "F1",
-                    ..Default::default()
+                    table_oid: 0,
+                    column_attr_number: 0,
+                    data_type_oid: 0,
+                    data_type_size: 0,
+                    type_modifier: 0,
+                    format_code: FormatCode::Text,
                 },
                 RowFieldBuilder {
                     name: "F2",
-                    ..Default::default()
+                    table_oid: 0,
+                    column_attr_number: 0,
+                    data_type_oid: 0,
+                    data_type_size: 0,
+                    type_modifier: 0,
+                    format_code: FormatCode::Text,
                 },
             ],
         };
@@ -1035,13 +1045,20 @@ mod tests {
                 RowFieldBuilder {
                     name: "F1",
                     column_attr_number: 1,
-                    ..Default::default()
+                    table_oid: 1,
+                    data_type_oid: 0,
+                    data_type_size: 0,
+                    type_modifier: 0,
+                    format_code: FormatCode::Text,
                 },
                 RowFieldBuilder {
                     name: "F2",
                     data_type_oid: 1234,
                     format_code: FormatCode::Binary,
-                    ..Default::default()
+                    table_oid: 2,
+                    column_attr_number: 2,
+                    data_type_size: 0,
+                    type_modifier: 0,
                 },
             ],
         };

--- a/gel-protocol/src/common.rs
+++ b/gel-protocol/src/common.rs
@@ -13,6 +13,7 @@ use crate::features::ProtocolVersion;
 
 pub use crate::client_message::{InputLanguage, IoFormat};
 
+#[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Cardinality {
     NoResult = 0x6e,

--- a/gel-protocol/src/encoding.rs
+++ b/gel-protocol/src/encoding.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut, RangeBounds};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -97,6 +98,9 @@ impl Output<'_> {
     }
     pub fn extend(&mut self, slice: &[u8]) {
         self.bytes.extend(slice)
+    }
+    pub fn uninit(&mut self) -> &mut [MaybeUninit<u8>] {
+        unsafe { self.bytes.chunk_mut().as_uninit_slice_mut() }
     }
 }
 

--- a/gel-protocol/src/new_protocol.rs
+++ b/gel-protocol/src/new_protocol.rs
@@ -118,7 +118,7 @@ struct RestoreReady<'a>: Message {
     /// Message headers.
     headers: Array<'a, i16, KeyValue<'a>>,
     /// Number of parallel jobs for restore.
-    jobs: i16,
+    jobs: u16,
 }
 
 /// The `CommandComplete` struct represents a message indicating a command has completed.
@@ -257,6 +257,8 @@ struct Authentication<'a>: Message {
     mlen: len,
     /// The type of authentication message.
     auth_status: i32,
+    /// The authentication data.
+    data: Rest<'a>,
 }
 
 /// The `AuthenticationOk` struct represents a successful authentication message.
@@ -743,7 +745,7 @@ enum TransactionState {
 #[derive(
     Clone, Copy, PartialEq, Eq, derive_more::Debug, derive_more::Error, derive_more::Display,
 )]
-#[repr(i32)]
+#[repr(u32)]
 pub enum EdbError {
     InternalServerError = 0x_01_00_00_00,
     UnsupportedFeatureError = 0x_02_00_00_00,
@@ -830,19 +832,19 @@ pub enum EdbError {
     ServerBlockedError = 0x_08_00_00_04,
     BackendError = 0x_09_00_00_00,
     UnsupportedBackendFeatureError = 0x_09_00_01_00,
-    LogMessage = 0x_F0_00_00_00_u32 as i32,
-    WarningMessage = 0x_F0_01_00_00_u32 as i32,
-    ClientError = 0x_FF_00_00_00_u32 as i32,
-    ClientConnectionError = 0x_FF_01_00_00_u32 as i32,
-    ClientConnectionFailedError = 0x_FF_01_01_00_u32 as i32,
-    ClientConnectionFailedTemporarilyError = 0x_FF_01_01_01_u32 as i32,
-    ClientConnectionTimeoutError = 0x_FF_01_02_00_u32 as i32,
-    ClientConnectionClosedError = 0x_FF_01_03_00_u32 as i32,
-    InterfaceError = 0x_FF_02_00_00_u32 as i32,
-    QueryArgumentError = 0x_FF_02_01_00_u32 as i32,
-    MissingArgumentError = 0x_FF_02_01_01_u32 as i32,
-    UnknownArgumentError = 0x_FF_02_01_02_u32 as i32,
-    InvalidArgumentError = 0x_FF_02_01_03_u32 as i32,
-    NoDataError = 0x_FF_03_00_00_u32 as i32,
-    InternalClientError = 0x_FF_04_00_00_u32 as i32,
+    LogMessage = 0x_F0_00_00_00_u32,
+    WarningMessage = 0x_F0_01_00_00_u32,
+    ClientError = 0x_FF_00_00_00_u32,
+    ClientConnectionError = 0x_FF_01_00_00_u32,
+    ClientConnectionFailedError = 0x_FF_01_01_00_u32,
+    ClientConnectionFailedTemporarilyError = 0x_FF_01_01_01_u32,
+    ClientConnectionTimeoutError = 0x_FF_01_02_00_u32,
+    ClientConnectionClosedError = 0x_FF_01_03_00_u32,
+    InterfaceError = 0x_FF_02_00_00_u32,
+    QueryArgumentError = 0x_FF_02_01_00_u32,
+    MissingArgumentError = 0x_FF_02_01_01_u32,
+    UnknownArgumentError = 0x_FF_02_01_02_u32,
+    InvalidArgumentError = 0x_FF_02_01_03_u32,
+    NoDataError = 0x_FF_03_00_00_u32,
+    InternalClientError = 0x_FF_04_00_00_u32,
 }

--- a/gel-protocol/src/new_protocol.rs
+++ b/gel-protocol/src/new_protocol.rs
@@ -62,7 +62,7 @@ struct ErrorResponse<'a>: Message {
     /// Message severity.
     severity: u8,
     /// Message code.
-    error_code: i32,
+    error_code: u32,
     /// Error message.
     message: LString<'a>,
     /// Error attributes.

--- a/gel-protocol/src/server_message.rs
+++ b/gel-protocol/src/server_message.rs
@@ -203,7 +203,7 @@ pub struct RawPacket {
     pub data: Bytes,
 }
 
-fn encode<T: Encode>(buf: &mut Output, _code: u8, msg: &T) -> Result<(), EncodeError> {
+fn encode<T: Encode>(buf: &mut Output, msg: &T) -> Result<(), EncodeError> {
     msg.encode(buf)?;
     Ok(())
 }
@@ -276,23 +276,23 @@ impl ServerMessage {
     pub fn encode(&self, buf: &mut Output) -> Result<(), EncodeError> {
         use ServerMessage::*;
         match self {
-            ServerHandshake(h) => encode(buf, 0x76, h),
-            ErrorResponse(h) => encode(buf, 0x45, h),
-            LogMessage(h) => encode(buf, 0x4c, h),
-            Authentication(h) => encode(buf, 0x52, h),
-            ReadyForCommand(h) => encode(buf, 0x5a, h),
-            ServerKeyData(h) => encode(buf, 0x4b, h),
-            ParameterStatus(h) => encode(buf, 0x53, h),
-            CommandComplete0(h) => encode(buf, 0x43, h),
-            CommandComplete1(h) => encode(buf, 0x43, h),
-            PrepareComplete(h) => encode(buf, 0x31, h),
-            CommandDataDescription0(h) => encode(buf, 0x54, h),
-            CommandDataDescription1(h) => encode(buf, 0x54, h),
-            StateDataDescription(h) => encode(buf, 0x73, h),
-            Data(h) => encode(buf, 0x44, h),
-            RestoreReady(h) => encode(buf, 0x2b, h),
-            DumpHeader(h) => encode(buf, 0x40, h),
-            DumpBlock(h) => encode(buf, 0x3d, h),
+            ServerHandshake(h) => encode(buf, h),
+            ErrorResponse(h) => encode(buf, h),
+            LogMessage(h) => encode(buf, h),
+            Authentication(h) => encode(buf, h),
+            ReadyForCommand(h) => encode(buf, h),
+            ServerKeyData(h) => encode(buf, h),
+            ParameterStatus(h) => encode(buf, h),
+            CommandComplete0(h) => encode(buf, h),
+            CommandComplete1(h) => encode(buf, h),
+            PrepareComplete(h) => encode(buf, h),
+            CommandDataDescription0(h) => encode(buf, h),
+            CommandDataDescription1(h) => encode(buf, h),
+            StateDataDescription(h) => encode(buf, h),
+            Data(h) => encode(buf, h),
+            RestoreReady(h) => encode(buf, h),
+            DumpHeader(h) => encode(buf, h),
+            DumpBlock(h) => encode(buf, h),
 
             UnknownMessage(_, _) => errors::UnknownMessageCantBeEncoded.fail()?,
         }

--- a/gel-protocol/src/server_message.rs
+++ b/gel-protocol/src/server_message.rs
@@ -38,14 +38,10 @@ use crate::descriptors::Typedesc;
 use crate::encoding::{Annotations, Decode, Encode, Input, KeyValues, Output};
 use crate::errors::{self, DecodeError, EncodeError, MessageTooLong};
 use crate::features::ProtocolVersion;
-<<<<<<< HEAD
-use crate::new_protocol;
-=======
 use crate::new_protocol::{
     self, prelude::EncoderForExt, AnnotationBuilder, ProtocolExtensionBuilder,
     ServerHandshakeBuilder,
 };
->>>>>>> 16381a9 (Use new serializer)
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -335,29 +331,6 @@ impl ServerMessage {
 
 impl Encode for ServerHandshake {
     fn encode(&self, buf: &mut Output) -> Result<(), EncodeError> {
-<<<<<<< HEAD
-        buf.reserve(6);
-        buf.put_u16(self.major_ver);
-        buf.put_u16(self.minor_ver);
-        buf.put_u16(
-            u16::try_from(self.extensions.len())
-                .ok()
-                .context(errors::TooManyExtensions)?,
-        );
-        for (name, headers) in &self.extensions {
-            name.encode(buf)?;
-            buf.reserve(2);
-            buf.put_u16(
-                u16::try_from(headers.len())
-                    .ok()
-                    .context(errors::TooManyHeaders)?,
-            );
-            for (name, value) in headers {
-                String::encode(name, buf)?;
-                String::encode(value, buf)?;
-            }
-        }
-=======
         let extensions = || {
             self.extensions.iter().map(|(name, headers)| {
                 let annotations = move || {
@@ -377,8 +350,6 @@ impl Encode for ServerHandshake {
         builder
             .encode_buffer(buf)
             .map_err(|_| MessageTooLong.build())?;
-
->>>>>>> 16381a9 (Use new serializer)
         Ok(())
     }
 }
@@ -410,22 +381,6 @@ impl Decode for ServerHandshake {
 
 impl Encode for ErrorResponse {
     fn encode(&self, buf: &mut Output) -> Result<(), EncodeError> {
-<<<<<<< HEAD
-        buf.reserve(11);
-        buf.put_u8(self.severity.to_u8());
-        buf.put_u32(self.code);
-        self.message.encode(buf)?;
-        buf.reserve(2);
-        buf.put_u16(
-            u16::try_from(self.attributes.len())
-                .ok()
-                .context(errors::TooManyHeaders)?,
-        );
-        for (name, value) in &self.attributes {
-            buf.put_u16(*name);
-            value.encode(buf)?;
-        }
-=======
         let builder = new_protocol::ErrorResponseBuilder {
             severity: self.severity.to_u8(),
             error_code: self.code,
@@ -444,7 +399,6 @@ impl Encode for ErrorResponse {
             .encode_buffer(buf)
             .map_err(|_| MessageTooLong.build())?;
 
->>>>>>> 16381a9 (Use new serializer)
         Ok(())
     }
 }


### PR DESCRIPTION
Use the new protocol definition for server message encoding to prove that it is correct.

Once message encoding and decoding is completely ported, the protocol code can be greatly simplified (not yet!)