### PR TITLE
Refactor array/string types

### DIFF
--- a/gel-db-protocol/src/arrays.rs
+++ b/gel-db-protocol/src/arrays.rs
@@ -315,6 +315,10 @@ mod tests {
         let mut buf = &data[..];
         let result = Array::<u32, u32>::decode_for(&mut buf);
         assert!(result.is_err());
+
+        let mut buf = [].as_slice();
+        let result = Array::<u32, u32>::decode_for(&mut buf);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -332,6 +336,19 @@ mod tests {
 
         let collected: Vec<u8> = array.into_iter().collect();
         assert_eq!(collected, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_zt_array_u32() {
+        // Unlikely, but helps test our primitive fast path
+        let data = vec![0xff, 0xff, 0xff, 0xff, 0xfe, 0xfe, 0xfe, 0xfe, 0];
+
+        let mut buf = &data[..];
+        let array = ZTArray::<u32>::decode_for(&mut buf).unwrap();
+
+        assert_eq!(array.len(), 2);
+        assert!(!array.is_empty());
+        assert_eq!(buf.len(), 0);
     }
 
     #[test]
@@ -359,6 +376,12 @@ mod tests {
         let mut buf = &data[..];
         let result = ZTArray::<u8>::decode_for(&mut buf);
         assert!(result.is_err());
+
+        // Test with empty arrays
+        let mut buf = [].as_slice();
+        assert!(ZTArray::<u8>::decode_for(&mut buf).is_err());
+        assert!(ZTArray::<u32>::decode_for(&mut buf).is_err());
+        assert!(ZTArray::<ZTString>::decode_for(&mut buf).is_err());
     }
 
     #[test]

--- a/gel-db-protocol/src/arrays.rs
+++ b/gel-db-protocol/src/arrays.rs
@@ -4,215 +4,193 @@ use crate::prelude::*;
 
 pub use std::marker::PhantomData;
 
-/// Inflated version of a zero-terminated array with zero-copy iterator access.
+/// Shared implementation for all array types.
+macro_rules! array_impl {
+    (#[$doc:meta] impl <$lt:lifetime, $generic:ident $(, $length_generic:ident)?> $ty:ident) => {
+        #[$doc]
+        #[derive(Copy, Clone, Default)]
+        pub struct $ty<$lt, $($length_generic,)? $generic>
+        where
+            $generic: DecoderFor<$lt, $generic>,
+        {
+            _phantom: PhantomData<( $generic , $( $length_generic)? )>,
+            buf: &'a [u8],
+            len: usize,
+        }
+
+        impl<$lt, $generic, $($length_generic)?> $ty<$lt, $($length_generic,)? $generic>
+        where
+            $generic: DecoderFor<$lt, $generic>,
+        {
+            #[inline(always)]
+            pub const fn new(buf: &$lt [u8], len: usize) -> Self {
+                Self {
+                    buf,
+                    len,
+                    _phantom: PhantomData,
+                }
+            }
+
+            #[inline(always)]
+            pub const fn empty() -> Self {
+                Self {
+                    buf: &[],
+                    len: 0,
+                    _phantom: PhantomData,
+                }
+            }
+
+            #[inline(always)]
+            pub const fn len(&self) -> usize {
+                self.len
+            }
+
+            #[inline(always)]
+            pub const fn is_empty(&self) -> bool {
+                self.len == 0
+            }
+
+            #[inline(always)]
+            pub const fn into_slice(self) -> &'a [u8] {
+                self.buf
+            }
+        }
+
+        impl<$lt, $generic, $($length_generic)?> std::fmt::Debug for $ty<$lt, $($length_generic,)? $generic>
+        where
+            $generic: DecoderFor<$lt, $generic>,
+            $generic: std::fmt::Debug,
+        {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_list().entries(self).finish()
+            }
+        }
+
+        // ZTArrays of type [`u8`] are special-cased to return a slice of bytes.
+        impl<$lt, $generic, $($length_generic)?> ArrayExt<$lt> for $ty<$lt, $($length_generic,)? $generic>
+        where
+            $generic: DecoderFor<$lt, $generic>,
+            $( $length_generic: $lt )?
+        {
+            #[inline(always)]
+            fn into_slice(self) -> &'a [u8] {
+                self.buf
+            }
+        }
+
+        impl<$lt, $generic, $($length_generic)?> AsRef<[u8]> for $ty<$lt, $($length_generic,)? $generic>
+        where
+            $generic: DecoderFor<$lt, $generic>,
+        {
+            #[inline(always)]
+            fn as_ref(&self) -> &[u8] {
+                self.buf
+            }
+        }
+
+        impl<$lt, $generic, $($length_generic)?> IntoIterator for $ty<$lt, $($length_generic,)? $generic>
+        where
+            $generic: DecoderFor<$lt, $generic>,
+        {
+            type Item = $generic;
+            type IntoIter = ArrayIter<'a, $generic>;
+            fn into_iter(self) -> Self::IntoIter {
+                Self::IntoIter {
+                    _phantom: PhantomData,
+                    buf: self.buf,
+                    len: self.len,
+                }
+            }
+        }
+
+        impl<$lt, $generic, $($length_generic)?> IntoIterator for &$ty<$lt, $($length_generic,)? $generic>
+        where
+            $generic: DecoderFor<$lt, $generic>,
+        {
+            type Item = $generic;
+            type IntoIter = ArrayIter<'a, $generic>;
+            fn into_iter(self) -> Self::IntoIter {
+                Self::IntoIter {
+                    _phantom: PhantomData,
+                    buf: self.buf,
+                    len: self.len,
+                }
+            }
+        }
+
+        // Arrays of fixed-size elements can extract elements in O(1).
+        impl<$lt, $generic, $($length_generic)?> $ty<$lt, $($length_generic,)? $generic>
+        where
+            $generic: DataTypeFixedSize + DecoderFor<$lt, $generic>,
+        {
+            #[inline]
+            pub fn get(&self, index: impl TryInto<usize>) -> Option<$generic> {
+                let Ok(index) = index.try_into() else {
+                    return None;
+                };
+                let index: usize = index;
+                if index >= self.len as _ {
+                    None
+                } else {
+                    let mut segment = &self.buf[T::SIZE * index..T::SIZE * (index + 1)];
+                    // As we've normally pre-scanned all items, this will not panic
+                    Some(T::decode_for(&mut segment).unwrap())
+                }
+            }
+        }
+
+        /// Arrays of `u8` can be indexed.
+        impl<$lt, $($length_generic)?> std::ops::Index<usize> for $ty<$lt, $($length_generic,)? u8> {
+            type Output = u8;
+            #[inline(always)]
+            fn index(&self, index: usize) -> &Self::Output {
+                &self.as_ref()[index]
+            }
+        }
+
+        /// Arrays of `u8` can be compared to slices.
+        impl<$lt, $($length_generic)?> PartialEq<&[u8]> for $ty<$lt, $($length_generic,)? u8>
+        {
+            fn eq(&self, other: &&[u8]) -> bool {
+                self.as_ref() == *other
+            }
+        }
+
+        /// Arrays of `u8` can be compared to fixed-size slices.
+        impl<$lt, $($length_generic, )? const N: usize> PartialEq<&[u8; N]> for $ty<$lt, $($length_generic,)? u8>
+        {
+            fn eq(&self, other: &&[u8; N]) -> bool {
+                self.as_ref() == *other
+            }
+        }
+    };
+}
+
+/// Shared trait for all array types.
+pub trait ArrayExt<'a>: 'a {
+    /// Convert the array into a slice of bytes.
+    fn into_slice(self) -> &'a [u8];
+}
+
+array_impl!(
+    /// A zero-terminated array.
+    impl <'a, T> ZTArray
+);
+array_impl!(
+    /// A count-prefixed array.
+    impl <'a, T, L> Array
+);
+array_impl!(
+    /// A rest array: consumes the remainder of the buffer.
+    impl <'a, T> RestArray
+);
+
+/// [`ZTArray`], [`Array`], and [`RestArray`] [`Iterator`] for values of type `T`.
 #[derive(Copy, Clone, Default)]
-pub struct ZTArray<'a, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    _phantom: PhantomData<T>,
-    buf: &'a [u8],
-    len: usize,
-}
-
-impl<'a, T> ZTArray<'a, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    #[inline(always)]
-    pub const fn new(buf: &'a [u8], len: usize) -> Self {
-        Self {
-            buf,
-            len,
-            _phantom: PhantomData,
-        }
-    }
-
-    #[inline(always)]
-    pub const fn len(&self) -> usize {
-        self.len
-    }
-
-    #[inline(always)]
-    pub const fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-}
-
-/// [`ZTArray`] [`Iterator`] for values of type `T`.
-pub struct ZTArrayIter<'a, T> {
-    _phantom: PhantomData<T>,
-    buf: &'a [u8],
-}
-
-impl<'a, T> std::fmt::Debug for ZTArray<'a, T>
-where
-    T: DecoderFor<'a, T>,
-    T: std::fmt::Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_list().entries(self).finish()
-    }
-}
-
-// ZTArrays of type [`u8`] are special-cased to return a slice of bytes.
-impl<'a> ZTArray<'a, u8> {
-    #[inline(always)]
-    pub fn into_slice(self) -> &'a [u8] {
-        self.buf
-    }
-}
-
-impl AsRef<[u8]> for ZTArray<'_, u8> {
-    #[inline(always)]
-    fn as_ref(&self) -> &[u8] {
-        &self.buf[..self.len as _]
-    }
-}
-
-impl<'a, T> IntoIterator for ZTArray<'a, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    type Item = T;
-    type IntoIter = ZTArrayIter<'a, T>;
-    fn into_iter(self) -> Self::IntoIter {
-        ZTArrayIter {
-            _phantom: PhantomData,
-            buf: self.buf,
-        }
-    }
-}
-
-impl<'a, T> IntoIterator for &ZTArray<'a, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    type Item = T;
-    type IntoIter = ZTArrayIter<'a, T>;
-    fn into_iter(self) -> Self::IntoIter {
-        ZTArrayIter {
-            _phantom: PhantomData,
-            buf: self.buf,
-        }
-    }
-}
-
-impl<'a, T> Iterator for ZTArrayIter<'a, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    type Item = T;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.buf[0] == 0 {
-            return None;
-        }
-        let value = T::decode_for(&mut self.buf).ok()?;
-        Some(value)
-    }
-}
-
-/// Inflated version of a length-specified array with zero-copy iterator access.
-#[derive(Copy, Clone, Default)]
-pub struct Array<'a, L, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    _phantom: PhantomData<(L, T)>,
-    buf: &'a [u8],
-    len: u32,
-}
-
-impl<'a, L, T> Array<'a, L, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    pub const fn empty() -> Self {
-        Self {
-            buf: &[],
-            len: 0,
-            _phantom: PhantomData,
-        }
-    }
-
-    pub const fn new(buf: &'a [u8], len: u32) -> Self {
-        Self {
-            buf,
-            len,
-            _phantom: PhantomData,
-        }
-    }
-
-    #[inline(always)]
-    pub const fn len(&self) -> usize {
-        self.len as usize
-    }
-
-    #[inline(always)]
-    pub const fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-}
-
-// Arrays of type [`u8`] are special-cased to return a slice of bytes.
-impl<'a, L> Array<'a, L, u8> {
-    #[inline(always)]
-    pub fn into_slice(self) -> &'a [u8] {
-        &self.buf[..self.len as _]
-    }
-}
-
-impl<T> AsRef<[u8]> for Array<'_, T, u8> {
-    #[inline(always)]
-    fn as_ref(&self) -> &[u8] {
-        &self.buf[..self.len as _]
-    }
-}
-
-impl<'a, L, T> std::fmt::Debug for Array<'a, L, T>
-where
-    T: DecoderFor<'a, T> + std::fmt::Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_list().entries(self).finish()
-    }
-}
-
-/// [`Array`] [`Iterator`] for values of type `T`.
 pub struct ArrayIter<'a, T> {
     _phantom: PhantomData<T>,
     buf: &'a [u8],
-    len: u32,
-}
-
-impl<'a, L, T> IntoIterator for Array<'a, L, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    type Item = T;
-    type IntoIter = ArrayIter<'a, T>;
-    fn into_iter(self) -> Self::IntoIter {
-        ArrayIter {
-            _phantom: PhantomData,
-            buf: self.buf,
-            len: self.len,
-        }
-    }
-}
-
-impl<'a, L, T> IntoIterator for &Array<'a, L, T>
-where
-    T: DecoderFor<'a, T>,
-{
-    type Item = T;
-    type IntoIter = ArrayIter<'a, T>;
-    fn into_iter(self) -> Self::IntoIter {
-        ArrayIter {
-            _phantom: PhantomData,
-            buf: self.buf,
-            len: self.len,
-        }
-    }
+    len: usize,
 }
 
 impl<'a, T> Iterator for ArrayIter<'a, T>
@@ -228,21 +206,84 @@ where
         let value = T::decode_for(&mut self.buf).ok()?;
         Some(value)
     }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
 }
 
-// Arrays of fixed-size elements can extract elements in O(1).
-impl<'a, L: TryInto<usize>, T: DataTypeFixedSize + DecoderFor<'a, T>> Array<'a, L, T> {
-    pub fn get(&self, index: L) -> Option<T> {
-        let Ok(index) = index.try_into() else {
-            return None;
-        };
-        let index: usize = index;
-        if index >= self.len as _ {
-            None
-        } else {
-            let mut segment = &self.buf[T::SIZE * index..T::SIZE * (index + 1)];
-            // As we've normally pre-scanned all items, this will not panic
-            Some(T::decode_for(&mut segment).unwrap())
-        }
+impl<'a, T> ExactSizeIterator for ArrayIter<'a, T>
+where
+    T: DecoderFor<'a, T>,
+{
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.len as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rest_array_u8() {
+        // Test with u8 values
+        let data = vec![1, 2, 3, 4, 5];
+        let mut buf = &data[..];
+        let rest_array = RestArray::<u8>::decode_for(&mut buf).unwrap();
+
+        assert_eq!(rest_array.len(), 5);
+        assert!(!rest_array.is_empty());
+        assert_eq!(buf.len(), 0); // Buffer should be consumed entirely
+
+        let collected: Vec<u8> = rest_array.into_iter().collect();
+        assert_eq!(collected, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_rest_array_u32() {
+        let data = vec![
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03,
+        ];
+
+        let mut buf = &data[..];
+        let rest_array = RestArray::<u32>::decode_for(&mut buf).unwrap();
+
+        assert_eq!(rest_array.len(), 3);
+        assert!(!rest_array.is_empty());
+        assert_eq!(buf.len(), 0); // Buffer should be consumed entirely
+
+        let collected: Vec<u32> = rest_array.into_iter().collect();
+        assert_eq!(collected, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_rest_array_empty() {
+        // Test with empty buffer
+        let data: Vec<u8> = vec![];
+        let mut buf = &data[..];
+        let rest_array = RestArray::<u8>::decode_for(&mut buf).unwrap();
+
+        assert_eq!(rest_array.len(), 0);
+        assert!(rest_array.is_empty());
+        assert_eq!(buf.len(), 0);
+
+        let collected: Vec<u8> = rest_array.into_iter().collect();
+        assert_eq!(collected, vec![]);
+    }
+
+    #[test]
+    fn test_rest_array_get() {
+        // Test get method for fixed-size elements
+        let data = vec![1u8, 2, 3, 4, 5];
+        let mut buf = &data[..];
+        let rest_array = RestArray::<u8>::decode_for(&mut buf).unwrap();
+
+        assert_eq!(rest_array.get(0), Some(1));
+        assert_eq!(rest_array.get(2), Some(3));
+        assert_eq!(rest_array.get(4), Some(5));
+        assert_eq!(rest_array.get(5), None); // Out of bounds
     }
 }

--- a/gel-db-protocol/src/encoding.rs
+++ b/gel-db-protocol/src/encoding.rs
@@ -1,8 +1,8 @@
 use std::mem::MaybeUninit;
 
 use crate::datatypes::*;
-use crate::declare_type;
 use crate::prelude::*;
+use crate::{declare_type, encoder_for_array};
 use uuid::Uuid;
 
 /// All data types must implement this trait. This allows for encoding and
@@ -155,86 +155,21 @@ where
         for _ in 0..len {
             T::decode_for(buf)?;
         }
+        let orig_buf = &orig_buf[0..orig_buf.len() - buf.len()];
         Ok(Array::new(orig_buf, len as _))
     }
 }
 
-impl<L: DataType + 'static, T: DataType + 'static, IT> EncoderFor<Array<'static, L, T>>
-    for &'_ [IT]
-where
-    IT: EncoderFor<T>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let iter = self.into_iter();
-        L::encode_usize(buf, self.len());
-        for elem in iter {
-            IT::encode_for(&elem, buf);
+encoder_for_array!(
+    impl <T, L> for Array<'static, L, T> {
+        fn encode_for(&self, buf: &mut BufWriter<'_>, it: impl ExactSizeIterator) {
+            L::encode_usize(buf, it.len());
+            for elem in it {
+                elem.encode_for(buf);
+            }
         }
     }
-}
-
-impl<L: DataType + 'static, T: DataType + 'static, const N: usize, IT>
-    EncoderFor<Array<'static, L, T>> for [IT; N]
-where
-    IT: EncoderFor<T>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let iter = self.into_iter();
-        L::encode_usize(buf, self.len());
-        for elem in iter {
-            IT::encode_for(&elem, buf);
-        }
-    }
-}
-
-impl<L: DataType + 'static, T: DataType + 'static, const N: usize, IT>
-    EncoderFor<Array<'static, L, T>> for &'_ [IT; N]
-where
-    IT: EncoderFor<T>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let iter = self.into_iter();
-        L::encode_usize(buf, self.len());
-        for elem in iter {
-            IT::encode_for(&elem, buf);
-        }
-    }
-}
-
-impl<'a, L, T, U> EncoderFor<Array<'static, L, T>> for Array<'a, L, U>
-where
-    L: DataType + 'static,
-    U: EncoderFor<T> + DecoderFor<'a, U>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        L::encode_usize(buf, self.len());
-        for elem in self.into_iter() {
-            U::encode_for(&elem, buf);
-        }
-    }
-}
-
-impl<L: DataType + 'static, T: DataType + 'static, F, I, II, IT> EncoderFor<Array<'static, L, T>>
-    for F
-where
-    F: Fn() -> I,
-    I: IntoIterator<Item = IT, IntoIter = II>,
-    IT: EncoderFor<T>,
-    II: ExactSizeIterator<Item = IT>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let iter = self().into_iter();
-        L::encode_usize(buf, II::len(&iter));
-        for elem in iter {
-            IT::encode_for(&elem, buf);
-        }
-    }
-}
+);
 
 impl<'a, T: DataType> DataType for ZTArray<'a, T>
 where
@@ -259,7 +194,7 @@ where
                 return Err(crate::prelude::ParseError::TooShort);
             }
             if buf[0] == 0 {
-                orig_buf = &orig_buf[0..orig_buf.len() - buf.len() + 1];
+                orig_buf = &orig_buf[0..orig_buf.len() - buf.len()];
                 *buf = &buf[1..];
                 break;
             }
@@ -270,79 +205,52 @@ where
     }
 }
 
-impl<T: DataType + 'static, IT> EncoderFor<ZTArray<'static, T>> for &'_ [IT]
-where
-    IT: EncoderFor<T>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let iter = self.into_iter();
-        for elem in iter {
-            IT::encode_for(&elem, buf);
+encoder_for_array!(
+    impl <T> for ZTArray<'static, T> {
+        fn encode_for(&self, buf: &mut BufWriter<'_>, it: impl Iterator) {
+            for elem in it {
+                elem.encode_for(buf);
+            }
+            buf.write(&[0]);
         }
-        buf.write(&[0]);
+    }
+);
+
+impl<'a, T: DataType> DataType for RestArray<'a, T>
+where
+    T: DecoderFor<'a, T>,
+{
+    const META: StructFieldMeta = declare_meta!(
+        type = RestArray,
+        constant_size = None,
+        flags = [array]
+    );
+}
+
+impl<'a, T: DataType> DecoderFor<'a, RestArray<'a, T>> for RestArray<'a, T>
+where
+    T: DecoderFor<'a, T>,
+{
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+        let orig_buf = *buf;
+        let mut len = 0;
+        while !buf.is_empty() {
+            T::decode_for(buf)?;
+            len += 1;
+        }
+        Ok(RestArray::new(orig_buf, len))
     }
 }
 
-impl<T: DataType + 'static, const N: usize, IT> EncoderFor<ZTArray<'static, T>> for [IT; N]
-where
-    IT: EncoderFor<T>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let iter = self.into_iter();
-        for elem in iter {
-            IT::encode_for(&elem, buf);
-        }
-        buf.write(&[0]);
-    }
-}
-
-impl<T: DataType + 'static, const N: usize, IT> EncoderFor<ZTArray<'static, T>> for &'_ [IT; N]
-where
-    IT: EncoderFor<T>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let iter = self.into_iter();
-        for elem in iter {
-            IT::encode_for(&elem, buf);
-        }
-        buf.write(&[0]);
-    }
-}
-
-impl<'a, T, U> EncoderFor<ZTArray<'static, T>> for ZTArray<'a, U>
-where
-    T: DataType + 'static,
-    T: DecoderFor<'static, T>,
-    U: DataType,
-    U: EncoderFor<T>,
-    U: DecoderFor<'a, U>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        for elem in self.into_iter() {
-            U::encode_for(&elem, buf);
+encoder_for_array!(
+    impl <T> for RestArray<'static, T> {
+        fn encode_for(&self, buf: &mut BufWriter<'_>, it: impl Iterator) {
+            for elem in it {
+                elem.encode_for(buf);
+            }
         }
     }
-}
-
-impl<T: DataType + 'static, F, I, II, IT> EncoderFor<ZTArray<'static, T>> for F
-where
-    F: Fn() -> I,
-    I: IntoIterator<Item = IT, IntoIter = II>,
-    IT: EncoderFor<T>,
-    II: Iterator<Item = IT>,
-    T: DecoderFor<'static, T>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let iter = self().into_iter();
-        for elem in iter {
-            IT::encode_for(&elem, buf);
-        }
-        buf.write(&[0]);
-    }
-}
+);
 
 impl<const N: usize, T: DataType> DataType for [T; N]
 where
@@ -453,58 +361,32 @@ where
 }
 
 declare_type!(DataType, LString<'a>, builder: &'a str, {});
+declare_type!(DataType, ZTString<'a>, builder: &'a str, {});
+declare_type!(DataType, RestString<'a>, builder: &'a str, {});
 
-impl<'a> DecoderFor<'a, LString<'a>> for LString<'a> {
-    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
-        let arr = Array::<u32, u8>::decode_for(buf)?;
-        Ok(LString::new(arr.into_slice()))
+impl<'a, A> DecoderFor<'a, ArrayString<'a, A>> for ArrayString<'a, A>
+where
+    A: ArrayExt<'a>,
+    A: DecoderFor<'a, A>,
+    A: DataType,
+    Self: DataType,
+{
+    fn decode_for(buf: &mut &'a [u8]) -> Result<ArrayString<'a, A>, ParseError> {
+        let arr = A::decode_for(buf)?;
+        Ok(ArrayString::new(arr.into_slice()))
     }
 }
 
-impl<T> EncoderFor<LString<'static>> for T
+impl<T, A> EncoderFor<ArrayString<'static, A>> for T
 where
     for<'any> &'any T: AsRef<str>,
+    A: AsRef<[u8]>,
+    A: 'static,
+    for<'any> &'any [u8]: EncoderFor<A>,
 {
     fn encode_for(&self, buf: &mut BufWriter<'_>) {
         let bytes = self.as_ref().as_bytes();
-        EncoderFor::<u32>::encode_for(&(bytes.len() as u32), buf);
-        buf.write(self.as_ref().as_bytes());
-    }
-}
-
-impl<'a> EncoderFor<LString<'static>> for LString<'a> {
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        let bytes = self.to_bytes();
-        EncoderFor::<u32>::encode_for(&(bytes.len() as u32), buf);
-        buf.write(bytes);
-    }
-}
-
-declare_type!(DataType, ZTString<'a>, builder: &'a str, {
-});
-
-impl<'a> DecoderFor<'a, ZTString<'a>> for ZTString<'a> {
-    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
-        let arr = ZTArray::<u8>::decode_for(buf)?;
-        let slice = arr.into_slice();
-        Ok(ZTString::new(&slice[0..slice.len() - 1]))
-    }
-}
-
-impl<T> EncoderFor<ZTString<'static>> for T
-where
-    for<'any> &'any T: AsRef<str>,
-{
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        buf.write(self.as_ref().as_bytes());
-        buf.write(&[0]);
-    }
-}
-
-impl<'a> EncoderFor<ZTString<'static>> for ZTString<'a> {
-    fn encode_for(&self, buf: &mut BufWriter<'_>) {
-        buf.write(self.to_bytes());
-        buf.write(&[0]);
+        bytes.encode_for(buf);
     }
 }
 
@@ -613,6 +495,46 @@ impl EncoderFor<Uuid> for &'_ Uuid {
 impl EncoderFor<Uuid> for Uuid {
     fn encode_for(&self, buf: &mut BufWriter<'_>) {
         buf.write(&self.into_bytes());
+    }
+}
+
+impl<T> DataType for LengthPrefixed<T>
+where
+    T: DataType,
+{
+    const META: StructFieldMeta = T::META;
+}
+
+impl<'a, T> DecoderFor<'a, LengthPrefixed<T>> for LengthPrefixed<T>
+where
+    T: DecoderFor<'a, T>,
+{
+    fn decode_for(buf: &mut &'a [u8]) -> Result<Self, ParseError> {
+        let len = u32::decode_for(buf)?;
+        if len > buf.len() as u32 {
+            return Err(ParseError::TooShort);
+        }
+        let mut inner_buf = &buf[..len as usize];
+        *buf = &buf[len as usize..];
+        // The inner object must consume the entire buffer.
+        let inner = T::decode_for(&mut inner_buf)?;
+        if inner_buf.len() != 0 {
+            return Err(ParseError::InvalidData("LengthPrefixed", inner_buf.len()));
+        }
+        Ok(LengthPrefixed(inner))
+    }
+}
+
+impl<T, U> EncoderFor<LengthPrefixed<T>> for LengthPrefixed<U>
+where
+    U: EncoderFor<T>,
+    T: 'static,
+{
+    fn encode_for(&self, buf: &mut BufWriter<'_>) {
+        let offset = buf.size();
+        U::encode_for(&self.0, buf);
+        let len = buf.size() - offset;
+        buf.write_rewind(offset, &len.to_be_bytes());
     }
 }
 

--- a/gel-db-protocol/src/gen.rs
+++ b/gel-db-protocol/src/gen.rs
@@ -257,6 +257,8 @@ macro_rules! make_static {
         _T<'a> => _T<'static>,
         _T<'a, _T2> => _T<'static, recurse!(_T2)>,
         _T<'a, _T2, _T3> => _T<'static, recurse!(_T2), recurse!(_T3)>,
+        _T<_T2> => _T<recurse!(_T2)>,
+        _T<_T2, _T3> => _T<recurse!(_T2), recurse!(_T3)>,
         _T => _T,
     }) };
 }

--- a/gel-db-protocol/src/lib.rs
+++ b/gel-db-protocol/src/lib.rs
@@ -11,9 +11,9 @@ mod writer;
 #[doc(hidden)]
 pub mod test_protocol;
 
-pub use arrays::{Array, ArrayIter, ZTArray, ZTArrayIter};
+pub use arrays::{Array, ArrayExt, ArrayIter, RestArray, ZTArray};
 pub use buffer::StructBuffer;
-pub use datatypes::{Encoded, LString, Length, Rest, Uuid, ZTString};
+pub use datatypes::{Encoded, LString, Length, Rest, RestString, Uuid, ZTString};
 pub use writer::BufWriter;
 
 #[doc(inline)]

--- a/gel-db-protocol/src/macros.rs
+++ b/gel-db-protocol/src/macros.rs
@@ -91,3 +91,110 @@ macro_rules! declare_meta {
 
     };
 }
+
+/// Generate encoders for array types from slices, arrays, and
+/// iterator-generating functions. Note that because we need to consume the
+/// iterator and we may need to iterate multiple times for measurement before
+/// serialization, we implement encoding for a function returning an iterator.
+///
+/// NOTE: For types that have a length generic, the length generic must appear
+/// second.
+#[macro_export]
+macro_rules! encoder_for_array {
+    (impl <$generic:ident $(, $length_generic:ident)?> for $ty:ty {
+        fn encode_for(&self, $buf:ident: &mut BufWriter<'_>, $it:ident: impl $iter:ident) $block:block
+    }) => {
+        /// Self encoder
+        impl<$generic : DataType, $($length_generic : DataType + 'static)?> EncoderFor<$ty> for $ty
+        where
+            $generic: EncoderFor<$generic>,
+            $generic: DecoderFor<'static, $generic>,
+        {
+            fn encode_for(&self, $buf: &mut $crate::BufWriter<'_>) {
+                let $it = self.into_iter();
+                $block
+            }
+        }
+
+        /// Slice encoder
+        impl<$generic : DataType, $($length_generic : DataType + 'static, )? IT> EncoderFor<$ty>
+            for &'_ [IT]
+        where
+            IT: EncoderFor<$generic>,
+            $generic: DecoderFor<'static, $generic>,
+        {
+            fn encode_for(&self, $buf: &mut $crate::BufWriter<'_>) {
+                let $it = self.into_iter();
+                $block
+            }
+        }
+
+        /// Array encoder
+        impl<$generic : DataType, $($length_generic : DataType + 'static, )? const N: usize, IT>
+            EncoderFor<$ty> for [IT; N]
+        where
+            IT: EncoderFor<$generic>,
+            $generic: DecoderFor<'static, $generic>,
+        {
+            fn encode_for(&self, $buf: &mut $crate::BufWriter<'_>) {
+                let $it = self.into_iter();
+                $block
+            }
+        }
+
+        /// Array reference encoder
+        impl<$generic : DataType, $($length_generic : DataType + 'static, )? const N: usize, IT>
+            EncoderFor<$ty> for &'_ [IT; N]
+        where
+            IT: EncoderFor<$generic>,
+            $generic: DecoderFor<'static, $generic>,
+        {
+            fn encode_for(&self, $buf: &mut $crate::BufWriter<'_>) {
+                let $it = self.into_iter();
+                $block
+            }
+        }
+
+        /// Function encoder: see the note about about non-restartable iterators.
+        impl<$generic : DataType, $($length_generic : DataType + 'static, )? F, I, II, IT> EncoderFor<$ty>
+            for F
+        where
+            F: Fn() -> I,
+            I: IntoIterator<Item = IT, IntoIter = II>,
+            IT: EncoderFor<$generic>,
+            II: $iter<Item = IT>,
+            $generic: DecoderFor<'static, $generic>,
+        {
+            fn encode_for(&self, $buf: &mut $crate::BufWriter<'_>) {
+                let $it = self().into_iter();
+                $block
+            }
+        }
+
+        /// Direct Vec<T> encoder
+        impl<$generic : DataType, $($length_generic : DataType + 'static, )? IT> EncoderFor<$ty>
+            for Vec<IT>
+        where
+            IT: EncoderFor<$generic>,
+            $generic: DecoderFor<'static, $generic>,
+        {
+            fn encode_for(&self, $buf: &mut $crate::BufWriter<'_>) {
+                let $it = self.iter();
+                $block
+            }
+        }
+
+        /// Direct &Vec<T> encoder
+        impl<$generic : DataType, $($length_generic : DataType + 'static, )? IT> EncoderFor<$ty>
+            for &'_ Vec<IT>
+        where
+            IT: EncoderFor<$generic>,
+            $generic: DecoderFor<'static, $generic>,
+        {
+            fn encode_for(&self, $buf: &mut $crate::BufWriter<'_>) {
+                let $it = self.iter();
+                $block
+            }
+        }
+    };
+}

--- a/gel-db-protocol/src/macros.rs
+++ b/gel-db-protocol/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! declare_type {
     // Primitive types (no lifetime, fixed size)
     ($ty:ident) =>
     {
-        $crate::declare_type!($crate::prelude::DataType, $ty, {
+        $crate::declare_type!($crate::prelude::DataType, $ty, flags=[primitive], {
             fn to_usize(value: usize) -> $ty {
                 value as $ty
             }

--- a/gel-db-protocol/src/structs.rs
+++ b/gel-db-protocol/src/structs.rs
@@ -62,6 +62,7 @@ pub struct StructFieldMeta {
     pub is_enum: bool,
     pub is_struct: bool,
     pub is_array: bool,
+    pub is_primitive: bool,
 }
 
 impl StructFieldMeta {
@@ -73,6 +74,7 @@ impl StructFieldMeta {
             is_enum: false,
             is_struct: false,
             is_array: false,
+            is_primitive: false,
         }
     }
 
@@ -100,6 +102,13 @@ impl StructFieldMeta {
     pub const fn set_array(self) -> Self {
         Self {
             is_array: true,
+            ..self
+        }
+    }
+
+    pub const fn set_primitive(self) -> Self {
+        Self {
+            is_primitive: true,
             ..self
         }
     }


### PR DESCRIPTION
We need a new "RestArray" and "RestString" type for the codec support. This refactors the arrays/string to reduce a lot of duplicated code and greatly simplifies the encoding bits for arrays.