### PR TITLE
Use dunce for canonicalization for a better Windows experience

### DIFF
--- a/gel-dsn/Cargo.toml
+++ b/gel-dsn/Cargo.toml
@@ -37,6 +37,7 @@ sha1 = "0.10"
 dirs = "6.0.0"
 whoami = "1.5"
 log = { optional = true, version = "0.4" }
+dunce = "1.0.3"
 
 gel-stream = { path = "../gel-stream", version = "0" }
 gel-errors = { path = "../gel-errors", version = "0" }

--- a/gel-dsn/src/file.rs
+++ b/gel-dsn/src/file.rs
@@ -212,7 +212,7 @@ impl FileAccess for SystemFileAccess {
     }
 
     fn canonicalize(&self, path: &Path) -> Result<PathBuf, std::io::Error> {
-        std::fs::canonicalize(path)
+        dunce::canonicalize(path)
     }
 
     fn list_dir(&self, path: &Path) -> Result<Vec<PathBuf>, std::io::Error> {


### PR DESCRIPTION
This prevents `\\?\` from showing up on most paths from this library. 

See https://github.com/rust-lang/rust/issues/42869 for more details